### PR TITLE
Polish the github issue summarization UI

### DIFF
--- a/github_issue_summarization/docker/Dockerfile
+++ b/github_issue_summarization/docker/Dockerfile
@@ -1,15 +1,13 @@
-FROM python:alpine
+FROM python:3.6
 
 COPY ./flask_web/requirements.txt /app/
 
 WORKDIR /app
 
 RUN pip install -r requirements.txt
-RUN pip install requests
 
 COPY ./flask_web /app
 
 ENTRYPOINT [ "python" ]
 
 CMD [ "app.py" ]
-

--- a/github_issue_summarization/docker/flask_web/requirements.txt
+++ b/github_issue_summarization/docker/flask_web/requirements.txt
@@ -1,2 +1,3 @@
 Flask==0.12.2
-
+pandas
+requests

--- a/github_issue_summarization/docker/flask_web/templates/index.html
+++ b/github_issue_summarization/docker/flask_web/templates/index.html
@@ -1,10 +1,53 @@
-<h1>Issue text</h1>
+<!doctype html>
+<html lang="en">
+  <head>
+    <!-- Required meta tags -->
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-<form action="summary" method="post">
-  <p>Enter GitHub issue text:</p>
-  <p><textarea class="scrollabletextbox" name="issue_text" rows=5 cols=100></textarea></p>
-  <p><input type="submit" value="Submit"/></p>
-</form>
+    <!-- Bootstrap CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 
+    <title>Github Issue Summarization!</title>
+  </head>
+  <body class="text-center">
+    <form class="form-signin" action="summary" method="post">
+      <img class="mb-4" src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" alt="" width="72" height="72">
+      <h1 style="margin-top: -20px;">Github Issue Summarization</h1>
+      <p style="margin-left: 20%; margin-right: 20%;">Instructions: This is a demo of the github issue summarization model by <a href="https://github.com/hamelsmu">Hamel Husain.</a> Enter the body of a github issue or the url of a github issue and click on Submit. The model then tries to generate a title or summary of the issue.</p>
+      <h3 class="h3 mb-3 font-weight-normal">Enter Github Issue Body</h3>
+      <p><button id="generate_random_issue_button" type="button">Populate Random Issue</button></p>
+      <p><textarea id="issue_body_textarea" class="scrollabletextbox" name="issue_text" rows=8 cols=100></textarea></p>
+      <h3 class="h3 mb-3 font-weight-normal">OR Enter Github Issue URL</h3>
+      <p><input id="issue_url_textarea" name="issue_url" type="text" size="100" placeholder="https://github.com/kubeflow/kubeflow/issues/157"></input></p>
+      <p><button id="submit" type="button">Generate Title</button></p>
+    </form>
+    <div id="generated_title_div" style="display: none;">
+      <h2>Machine Generated Title</h2>
+      <p id="generated_title"></p>
+    </div>
 
+    <!-- Optional JavaScript -->
+    <!-- jQuery first, then Popper.js, then Bootstrap JS -->
+    <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
+    <script type="text/javascript">
+      $("#generate_random_issue_button").click(function(){
+          $.ajax({url: window.location.pathname + "random_github_issue", success: function(result){
+              $("#issue_body_textarea").html(result.body);
+          }});
+      });
+      $("#submit").click(function(){
+          var issue_body_textarea = $("#issue_body_textarea").val();
+          var issue_url_textarea = $("#issue_url_textarea").val();
+          $.post(window.location.pathname + "summary", {issue_text: issue_body_textarea, issue_url: issue_url_textarea}, function(result){
+              $("#generated_title").html(result.summary);
+              $("#issue_body_textarea").html(result.body);
+              $("#generated_title_div").show();
 
+          });
+      });
+    </script>
+  </body>
+</html>

--- a/github_issue_summarization/docker/flask_web/templates/index.html
+++ b/github_issue_summarization/docker/flask_web/templates/index.html
@@ -8,13 +8,13 @@
     <!-- Bootstrap CSS -->
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
 
-    <title>Github Issue Summarization!</title>
+    <title>Github Issue Summarization</title>
   </head>
   <body class="text-center">
     <form class="form-signin" action="summary" method="post">
       <img class="mb-4" src="https://assets-cdn.github.com/images/modules/logos_page/GitHub-Mark.png" alt="" width="72" height="72">
       <h1 style="margin-top: -20px;">Github Issue Summarization</h1>
-      <p style="margin-left: 20%; margin-right: 20%;">Instructions: This is a demo of the github issue summarization model by <a href="https://github.com/hamelsmu">Hamel Husain.</a> Enter the body of a github issue or the url of a github issue and click on Submit. The model then tries to generate a title or summary of the issue.</p>
+      <p style="margin-left: 20%; margin-right: 20%;">Instructions: This is a demo of the github issue summarization <a href="https://github.com/hamelsmu/Seq2Seq_Tutorial" target="_blank">model</a> by <a href="https://github.com/hamelsmu" target="_blank">Hamel Husain.</a> Enter the body of a github issue or the url of a github issue and click on Submit. The model then tries to generate a title or summary of the issue.</p>
       <h3 class="h3 mb-3 font-weight-normal">Enter Github Issue Body</h3>
       <p><button id="generate_random_issue_button" type="button">Populate Random Issue</button></p>
       <p><textarea id="issue_body_textarea" class="scrollabletextbox" name="issue_text" rows=8 cols=100></textarea></p>
@@ -24,8 +24,9 @@
     </form>
     <div id="generated_title_div" style="display: none;">
       <h2>Machine Generated Title</h2>
-      <p id="generated_title"></p>
+      <p style="margin-right: 20%; margin-left: 20%;" id="generated_title"></p>
     </div>
+    <p style="font-style: italic; margin-right: 20%; margin-left: 20%; margin-top: 40px;" id="generated_title">This demo is run using <a target="_blank" href="https://github.com/kubeflow/kubeflow/">Kubeflow</a> - a machine learning toolkit for Kubernetes. Kubeflow is dedicated to making deployment of machine learning on Kubernetes simple, portable and scalable.</p>
 
     <!-- Optional JavaScript -->
     <!-- jQuery first, then Popper.js, then Bootstrap JS -->
@@ -39,10 +40,11 @@
           }});
       });
       $("#submit").click(function(){
+          $("#generated_title").html("");
           var issue_body_textarea = $("#issue_body_textarea").val();
           var issue_url_textarea = $("#issue_url_textarea").val();
           $.post(window.location.pathname + "summary", {issue_text: issue_body_textarea, issue_url: issue_url_textarea}, function(result){
-              $("#generated_title").html(result.summary);
+              $("#generated_title").html("“" + result.summary + "”");
               $("#issue_body_textarea").html(result.body);
               $("#generated_title_div").show();
 

--- a/github_issue_summarization/docker/flask_web/templates/issue_summary.html
+++ b/github_issue_summarization/docker/flask_web/templates/issue_summary.html
@@ -1,7 +1,0 @@
-<h1>Issue Summary</h1>
-<p>{{issue_summary}}</p>
-
-<h2>Issue text</h1>
-<p>{{issue_text}}</p>
-
-


### PR DESCRIPTION
* Add bootstrap css
* Add support to enter Issue URL
* Add support to populate a random issue
* Show the result on the same page instead of redirecting to a new page

Fixes https://github.com/kubeflow/examples/issues/75

Deployed to https://dev.kubeflow.org/issue-summarization/

/cc @texasmichelle

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/69)
<!-- Reviewable:end -->
