### PR TITLE
Support training using a PVC for the data.

### DIFF
--- a/github_issue_summarization/ks-kubeflow/app.yaml
+++ b/github_issue_summarization/ks-kubeflow/app.yaml
@@ -12,6 +12,12 @@ environments:
       server: https://35.188.73.10
     k8sVersion: v1.7.0
     path: default
+  jlewi:
+    destination:
+      namespace: jlewi
+      server: https://35.188.73.10
+    k8sVersion: v1.7.0
+    path: jlewi
 kind: ksonnet.io/app
 libraries:
   core:

--- a/github_issue_summarization/ks-kubeflow/components/params.libsonnet
+++ b/github_issue_summarization/ks-kubeflow/components/params.libsonnet
@@ -48,7 +48,7 @@
       namespace: "null",
     },
     "tfjob-pvc": {
-      image: "gcr.io/kubeflow-dev/tf-job-issue-summarization:v20180424-cc334b0-dirty-845fff",
+      image: "gcr.io/kubeflow-dev/tf-job-issue-summarization:v20180425-e79f888",
       input_data: "/data/github_issues.csv",
       namespace: "null",
       output_model: "/data/model.h5",

--- a/github_issue_summarization/ks-kubeflow/components/params.libsonnet
+++ b/github_issue_summarization/ks-kubeflow/components/params.libsonnet
@@ -47,6 +47,13 @@
     tfjob: {
       namespace: "null",
     },
+    "tfjob-pvc": {
+      image: "gcr.io/kubeflow-dev/tf-job-issue-summarization:v20180424-cc334b0-dirty-845fff",
+      input_data: "/data/github_issues.csv",
+      namespace: "null",
+      output_model: "/data/model.h5",
+      sample_size: "2000000",
+    },
     ui: {
       namespace: "null",
     },

--- a/github_issue_summarization/ks-kubeflow/components/tfjob-pvc.jsonnet
+++ b/github_issue_summarization/ks-kubeflow/components/tfjob-pvc.jsonnet
@@ -1,0 +1,61 @@
+// Train the model reading & writing the data from a PVC.
+local env = std.extVar("__ksonnet/environments");
+local params = std.extVar("__ksonnet/params").components["tfjob-pvc"];
+local k = import "k.libsonnet";
+
+local tfjob = {
+    apiVersion: "kubeflow.org/v1alpha1",
+    kind: "TFJob",
+    metadata: {
+      name: "tf-job-issue-summarization-pvc",
+      namespace: env.namespace,
+    },
+    spec: {
+      replicaSpecs: [
+        {
+          replicas: 1,
+          template: {
+            spec: {
+              containers: [
+                {
+                  image: params.image,
+                  name: "tensorflow",
+                  volumeMounts: [
+                    {
+                      name: "data",
+                      mountPath: "/data",                    
+                    },
+                  ],
+                  command: [
+                    "python",
+                    "/workdir/train.py",
+                    "--sample_size=" + std.toString(params.sample_size),
+                    "--input_data=" + params.input_data,
+                    "--output_model=" + params.output_model,                    
+                  ],
+                },
+              ],
+              volumes: [
+                    {
+		            name: "data",
+		            persistentVolumeClaim: {
+		              claimName: "data-pvc",
+		            },
+		          },
+              ],
+              restartPolicy: "OnFailure",
+            },
+          },
+          tfReplicaType: "MASTER",
+        },
+      ],
+      terminationPolicy: {
+        chief: {
+          replicaIndex: 0,
+          replicaName: "MASTER",
+        },
+      },
+    },
+  };
+
+std.prune(k.core.v1.list.new([tfjob]))

--- a/github_issue_summarization/ks-kubeflow/components/tfjob.libsonnet
+++ b/github_issue_summarization/ks-kubeflow/components/tfjob.libsonnet
@@ -28,7 +28,7 @@
                   ],
                   args: [
                     "/workdir/train.py",
-                    "--sample_size=" + params.sample_size,
+                    "--sample_size=" + std.toString(params.sample_size),
                     "--input_data_gcs_bucket=" + params.input_data_gcs_bucket,
                     "--input_data_gcs_path=" + params.input_data_gcs_path,
                     "--output_model_gcs_bucket=" + params.output_model_gcs_bucket,

--- a/github_issue_summarization/ks-kubeflow/environments/jlewi/main.jsonnet
+++ b/github_issue_summarization/ks-kubeflow/environments/jlewi/main.jsonnet
@@ -1,0 +1,7 @@
+local base = import "base.libsonnet";
+local k = import "k.libsonnet";
+
+base + {
+  // Insert user-specified overrides here. For example if a component is named "nginx-deployment", you might have something like:
+  //   "nginx-deployment"+: k.deployment.mixin.metadata.labels({foo: "bar"})
+}

--- a/github_issue_summarization/ks-kubeflow/environments/jlewi/params.libsonnet
+++ b/github_issue_summarization/ks-kubeflow/environments/jlewi/params.libsonnet
@@ -1,0 +1,10 @@
+local params = import "../../components/params.libsonnet";
+params + {
+  components +: {
+    // Insert component parameter overrides here. Ex:
+    // guestbook +: {
+    //   name: "guestbook-dev",
+    //   replicas: params.global.replicas,
+    // },
+  },
+}

--- a/github_issue_summarization/notebooks/Dockerfile
+++ b/github_issue_summarization/notebooks/Dockerfile
@@ -1,3 +1,9 @@
 FROM gcr.io/kubeflow-images-staging/tensorflow-1.6.0-notebook-cpu
+RUN pip install ktext
+RUN pip install annoy
+RUN pip install --upgrade google-cloud
+RUN pip install sklearn h5py
+RUN pip install nltk
+
 COPY train.py /workdir/train.py
 COPY seq2seq_utils.py /workdir/seq2seq_utils.py

--- a/github_issue_summarization/notebooks/Makefile
+++ b/github_issue_summarization/notebooks/Makefile
@@ -1,0 +1,41 @@
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Requirements:
+#   https://github.com/mattrobenolt/jinja2-cli
+#   pip install jinja2-clie
+# Update the Airflow deployment
+
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | sha256sum | cut -c -6)
+DIR := ${CURDIR}
+
+# You can override this on the command line as
+# make PROJECT=kubeflow-examples <target>
+PROJECT := kubeflow-examples
+
+# TPU uses the same docker image as CPU .
+IMG := gcr.io/$(PROJECT)/tf-job-issue-summarization
+
+push: build
+	gcloud docker -- push $(IMG):$(TAG)
+
+set-image: push
+	# Set the image to use
+	cd ../ks-kubeflow && ks param set tfjob-pvc image $(IMG):$(TAG)
+
+# To build without the cache set the environment variable
+# export DOCKER_BUILD_OPTS=--no-cache
+build:
+	docker build ${DOCKER_BUILD_OPTS} -f Dockerfile -t $(IMG):$(TAG) ./
+	@echo Built $(IMG):$(TAG)

--- a/github_issue_summarization/notebooks/Makefile
+++ b/github_issue_summarization/notebooks/Makefile
@@ -17,16 +17,31 @@
 #   pip install jinja2-clie
 # Update the Airflow deployment
 
-TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | sha256sum | cut -c -6)
+# List any changed  files. We only include files in the notebooks directory.
+# because that is the code in the docker image.
+# In particular we exclude changes to the ksonnet configs.
+CHANGED_FILES := $(shell git diff-files --relative=github_issue_summarization/notebooks)
+
+ifeq ($(strip $(CHANGED_FILES)),)
+# Changed files is empty; not dirty
+# Don't include --dirty because it could be dirty if files outside the ones we care
+# about changed.
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always)
+else
+TAG := $(shell date +v%Y%m%d)-$(shell git describe --tags --always --dirty)-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
 DIR := ${CURDIR}
 
 # You can override this on the command line as
 # make PROJECT=kubeflow-examples <target>
 PROJECT := kubeflow-examples
 
-# TPU uses the same docker image as CPU .
 IMG := gcr.io/$(PROJECT)/tf-job-issue-summarization
 
+echo:
+	@echo changed files $(CHANGED_FILES)
+	@echo tag $(TAG)
 push: build
 	gcloud docker -- push $(IMG):$(TAG)
 

--- a/github_issue_summarization/notebooks/train.py
+++ b/github_issue_summarization/notebooks/train.py
@@ -19,10 +19,10 @@ import os
 import re
 import zipfile
 
+from google.cloud import storage  # pylint: disable=no-name-in-module
 import dill as dpickle
 import numpy as np
 import pandas as pd
-from google.cloud import storage  # pylint: disable=no-name-in-module
 from keras import optimizers
 from keras.layers import GRU, BatchNormalization, Dense, Embedding, Input
 from keras.models import Model

--- a/github_issue_summarization/training_the_model_tfjob.md
+++ b/github_issue_summarization/training_the_model_tfjob.md
@@ -26,7 +26,7 @@ ks apply --env=${KF_ENV} -c data-pvc
 	* Your cluster must have a default storage class defined for
 	  this to work.
 
-Run the job to downlaod the data to the PVC.
+Run the job to download the data to the PVC.
 
 ```
 ks apply --env=${KF_ENV} -c data-downloader


### PR DESCRIPTION
* This will make it easier to run the example on Katacoda and non-GCP platforms.

* Modify train.py so we can use a GCS location or local file paths.

* Update the Dockerfile. The jupyter Docker images and had a bunch of
  dependencies removed and the latest images don't have the dependencies
  needed to run the examples.

* Creat a tfjob-pvc component that trains reading/writing using PVC
  and not GCP.

Related to #91

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/98)
<!-- Reviewable:end -->
