### PR TITLE
Fix utf-8 encoding issues in data pre-processing

### DIFF
--- a/code_search/preprocess/preprocess/pipeline.py
+++ b/code_search/preprocess/preprocess/pipeline.py
@@ -70,7 +70,7 @@ class ExtractFuncInfo(beam.DoFn):
   def dict_to_unicode(data_dict):
     for k, v in data_dict.items():
       if isinstance(v, str):
-        data_dict[k] = v.encode('utf-8', 'ignore')
+        data_dict[k] = v.decode('utf-8', 'ignore')
     return data_dict
 
 

--- a/code_search/preprocess/preprocess/tokenizer.py
+++ b/code_search/preprocess/preprocess/tokenizer.py
@@ -7,7 +7,7 @@ from nltk.tokenize import RegexpTokenizer
 def tokenize_docstring(text):
   """Apply tokenization using spacy to docstrings."""
   en = spacy.load('en')
-  tokens = en.tokenizer(text.decode('utf8'))
+  tokens = en.tokenizer(text.decode('utf8', 'ignore'))
   return [token.text.lower() for token in tokens if not token.is_space]
 
 


### PR DESCRIPTION
This update fixes the occasional `utf-8` errors during tokenization.

A representative error looked like

```
RuntimeError: UnicodeDecodeError: 'ascii' codec can't decode byte 0xe6 in position 654: ordinal not in range(128) [while running 'BigQueryGithubFiles/Extract Function Info']
```

This was happening at the Extract Function Info phase which needs to store the tokenized values into a Python `dict`. The assumption for ignoring such characters is that they would not add much value to the language model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/122)
<!-- Reviewable:end -->
