### PR TITLE
Add custom metrics, write raw tokens to GCS

### DIFF
--- a/code_search/preprocess/scripts/process_github_archive.py
+++ b/code_search/preprocess/scripts/process_github_archive.py
@@ -32,7 +32,7 @@ def main(args):
     query_string = f.read()
 
   pipeline = beam.Pipeline(options=pipeline_opts)
-  (pipeline | ProcessGithubFiles(args.project, query_string, args.output)) #pylint: disable=expression-not-assigned
+  (pipeline | ProcessGithubFiles(args.project, query_string, args.output, args.storage_bucket)) #pylint: disable=expression-not-assigned
   pipeline.run()
 
 


### PR DESCRIPTION
This step is meant to be used as a step before generating the negative samples for the new architecture. Using GCS for output storage. The cost to write to GCS seems to be at par with the cost to write to BigQuery.

/cc @jlewi @ankushagarwal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/141)
<!-- Reviewable:end -->
