### PR TITLE
Fix v1alpha2 version of the T2T training job.

### DIFF
--- a/github_issue_summarization/ks-kubeflow/components/data-pvc.jsonnet
+++ b/github_issue_summarization/ks-kubeflow/components/data-pvc.jsonnet
@@ -5,7 +5,6 @@ local env = std.extVar("__ksonnet/environments");
 local params = std.extVar("__ksonnet/params").components["data-pvc"];
 local k = import "k.libsonnet";
 
-
 local pvc = {
   apiVersion: "v1",
   kind: "PersistentVolumeClaim",

--- a/github_issue_summarization/ks-kubeflow/components/params.libsonnet
+++ b/github_issue_summarization/ks-kubeflow/components/params.libsonnet
@@ -91,5 +91,8 @@
       name: "tensor2tensor-v1alpha2",
     },
     "data-downloader": {},
+    "tfjob-pvc-v1alpha2": {
+      name: "tfjob-pvc-v1alpha2",
+    },
   },
 }

--- a/github_issue_summarization/ks-kubeflow/components/tfjob-pvc-v1alpha2.jsonnet
+++ b/github_issue_summarization/ks-kubeflow/components/tfjob-pvc-v1alpha2.jsonnet
@@ -1,0 +1,70 @@
+local env = std.extVar("__ksonnet/environments");
+local overrideParams = std.extVar("__ksonnet/params").components["tfjob-pvc-v1alpha2"];
+
+local k = import "k.libsonnet";
+
+local namespace = env.namespace;
+
+local defaultParams = {
+  image: "gcr.io/kubeflow-dev/tf-job-issue-summarization:v20180425-e79f888",
+  input_data: "/data/github_issues.csv",
+
+  output_model: "/data/model.h5",
+  sample_size: "2000000",
+  claim_name: "data-pvc",
+};
+
+local params = defaultParams + overrideParams;
+local name = params.name;
+
+local tfjob = {
+  apiVersion: "kubeflow.org/v1alpha2",
+  kind: "TFJob",
+  metadata: {
+    name: name,
+    namespace: namespace,
+  },
+  spec: {
+    tfReplicaSpecs: {
+      Master: {
+        replicas: 1,
+        template: {
+          spec: {
+            containers: [
+              {
+                image: params.image,
+                name: "tensorflow",
+                volumeMounts: [
+                  {
+                    name: "data",
+                    mountPath: "/data",
+                  },
+                ],
+                command: [
+                  "python",
+                  "/workdir/train.py",
+                  "--sample_size=" + std.toString(params.sample_size),
+                  "--input_data=" + params.input_data,
+                  "--output_model=" + params.output_model,
+                ],
+              },
+            ],
+            volumes: [
+              {
+                name: "data",
+                persistentVolumeClaim: {
+                  claimName: params.claim_name,
+                },
+              },
+            ],
+            restartPolicy: "OnFailure",
+          },
+        },  // template
+      },
+    },
+  },
+};
+
+k.core.v1.list.new([
+  tfjob,
+])

--- a/github_issue_summarization/tensor2tensor/github/Dockerfile
+++ b/github_issue_summarization/tensor2tensor/github/Dockerfile
@@ -6,7 +6,7 @@ ARG BASE_IMAGE=gcr.io/kubeflow-images-public/tensorflow-1.7.0-notebook-gpu:lates
 FROM $BASE_IMAGE
 
 # Install pip packages as user jovyan
-RUN pip install tensor2tensor h5py
+RUN pip install tensor2tensor==1.6.6 h5py
 
 USER root
 


### PR DESCRIPTION
* Update the Docker image for T2T to use a newer version of T2T library

* Add parameters to set the GCP secret; we need GCP credentials to
  read from GCS even if reading a public bucket. We default
  to the parameters that are created automatically in the case of a GKE
  deployment.

* Create a v1alpha2 template for the job that uses PVC.

/assign @texasmichelle 