### PR TITLE
Fix transformer export

### DIFF
--- a/code_search/app/code_search/nmslib/cli.py
+++ b/code_search/app/code_search/nmslib/cli.py
@@ -25,7 +25,7 @@ def parse_server_args(args):
                      help='Path to index file created by nmslib')
   parser.add_argument('--problem', type=str, required=True,
                       help='Name of the T2T problem')
-  parser.add_argument('--data-dir', type=str, metavar='', default='/tmp',
+  parser.add_argument('--data-dir', type=str, required=True,
                      help='Path to working data directory')
   parser.add_argument('--serving-url', type=str, required=True,
                       help='Complete URL to TF Serving Inference server')
@@ -52,7 +52,12 @@ def parse_creator_args(args):
   parser.add_argument('--tmp-dir', type=str, metavar='', default='/tmp/nmslib',
                      help='Path to temporary data directory')
 
-  return parser.parse_args(args)
+  args = parser.parse_args(args)
+  args.data_file = os.path.expanduser(args.data_file)
+  args.index_file = os.path.expanduser(args.index_file)
+  args.tmp_dir = os.path.expanduser(args.tmp_dir)
+
+  return args
 
 def server():
   args = parse_server_args(sys.argv[1:])
@@ -78,8 +83,6 @@ def creator():
     os.makedirs(args.tmp_dir, exist_ok=True)
 
   data_file = maybe_download_gcs_file(args.data_file, args.tmp_dir)
-
-  # TODO(sanyamkapoor): parse data file into a numpy array
 
   data = np.load(data_file)
 

--- a/code_search/app/code_search/nmslib/gcs.py
+++ b/code_search/app/code_search/nmslib/gcs.py
@@ -62,6 +62,7 @@ def upload_gcs_file(src_file, target_file):
 def maybe_upload_gcs_file(src_file, target_file):
   """Wraps `upload_gcs_file` with checks"""
   if not is_gcs_path(target_file):
+    os.rename(src_file, target_file)
     return target_file
 
   return upload_gcs_file(src_file, target_file)

--- a/code_search/app/code_search/nmslib/search_engine.py
+++ b/code_search/app/code_search/nmslib/search_engine.py
@@ -20,15 +20,12 @@ class CodeSearchEngine:
     self.index.loadIndex(index_file)
 
   def embed(self, query_str):
-    """This function gets the vector embedding from
-    the target inference server. The steps involved are
-    encoding the input query and decoding the responses
-    from the TF Serving service
-    TODO(sanyamkapoor): This code is still under construction
-    and only representative of the steps needed to build the
-    embedding
+    """Get query embedding from TFServing
+
+    This involves encoding the input query
+    for the TF Serving service
     """
-    encoder, decoder = get_encoder_decoder(self._problem, self._data_dir)
+    encoder, _ = get_encoder_decoder(self._problem, self._data_dir)
     encoded_query = encode_query(encoder, query_str)
     data = {"instances": [{"input": {"b64": encoded_query}}]}
 
@@ -37,10 +34,8 @@ class CodeSearchEngine:
                              data=json.dumps(data))
 
     result = response.json()
-    for prediction in result['predictions']:
-      prediction['outputs'] = decoder.decode(prediction['outputs'])
-
-    return result['predicts'][0]['outputs']
+    result['predictions'] = [preds['outputs'] for preds in result['predictions']]
+    return result
 
   def query(self, query_str: str, k=2):
     embedding = self.embed(query_str)

--- a/code_search/app/code_search/nmslib/search_server.py
+++ b/code_search/app/code_search/nmslib/search_server.py
@@ -11,6 +11,8 @@ class CodeSearchServer:
     self.port = port
     self.engine = engine
 
+    self.init_routes()
+
   def init_routes(self):
     # pylint: disable=unused-variable
 
@@ -20,12 +22,22 @@ class CodeSearchServer:
 
     @self.app.route('/query')
     def query():
-      query_str = request.args.get('query')
+      query_str = request.args.get('q')
       if not query_str:
         abort(make_response(
           jsonify(status=400, error="empty query"), 400))
 
       result = self.engine.query(query_str)
+      return make_response(jsonify(result=result))
+
+    @self.app.route('/embed')
+    def embed():
+      query_str = request.args.get('q')
+      if not query_str:
+        abort(make_response(
+          jsonify(status=400, error="empty query"), 400))
+
+      result = self.engine.embed(query_str)
       return make_response(jsonify(result=result))
 
   def run(self):

--- a/code_search/app/code_search/t2t/function_docstring.py
+++ b/code_search/app/code_search/t2t/function_docstring.py
@@ -6,7 +6,11 @@ from tensor2tensor.utils import metrics
 from tensor2tensor.utils import registry
 
 
-# There are 10 splits of the data as CSV files.
+##
+# These URLs are only for fallback purposes in case the specified
+# `data_dir` does not contain the data. However, note that the data
+# files must have the same naming pattern.
+#
 _DATA_BASE_URL = 'https://storage.googleapis.com/kubeflow-examples/t2t-code-search/data'
 _GITHUB_FUNCTION_DOCSTRING_FILES = [
     [

--- a/code_search/app/code_search/t2t/function_docstring.py
+++ b/code_search/app/code_search/t2t/function_docstring.py
@@ -32,7 +32,7 @@ class GithubFunctionDocstring(translate.TranslateProblem):
   def approx_vocab_size(self):
     return 2**13
 
-  def source_data_files(self, dataset_split):
+  def source_data_files(self, dataset_split):  # pylint: disable=no-self-use,unused-argument
     # TODO(sanyamkapoor): separate train/eval data set.
     return _GITHUB_FUNCTION_DOCSTRING_FILES
 

--- a/code_search/app/code_search/t2t/function_docstring.py
+++ b/code_search/app/code_search/t2t/function_docstring.py
@@ -1,14 +1,24 @@
 """Github function/text similatrity problems."""
 import csv
-import glob
-import os
-from tensor2tensor.data_generators import text_problems
+from tensor2tensor.data_generators import generator_utils
+from tensor2tensor.data_generators import translate
 from tensor2tensor.utils import metrics
 from tensor2tensor.utils import registry
 
 
+# There are 10 splits of the data as CSV files.
+_DATA_BASE_URL = 'https://storage.googleapis.com/kubeflow-examples/t2t-code-search/data'
+_GITHUB_FUNCTION_DOCSTRING_FILES = [
+    [
+        '{}/pairs-0000{}-of-00010.csv'.format(_DATA_BASE_URL, i),
+        'pairs-0000{}-of-00010.csv'.format(i),
+    ]
+    for i in range(10)
+]
+
+
 @registry.register_problem
-class GithubFunctionDocstring(text_problems.Text2TextProblem):
+class GithubFunctionDocstring(translate.TranslateProblem):
   # pylint: disable=abstract-method
 
   """This class defines the problem of finding similarity between Python
@@ -22,13 +32,20 @@ class GithubFunctionDocstring(text_problems.Text2TextProblem):
   def approx_vocab_size(self):
     return 2**13
 
+  def source_data_files(self, dataset_split):
+    # TODO(sanyamkapoor): separate train/eval data set.
+    return _GITHUB_FUNCTION_DOCSTRING_FILES
+
   def generate_samples(self, data_dir, tmp_dir, dataset_split):  # pylint: disable=no-self-use,unused-argument
     """Returns a generator to return {"inputs": [text], "targets": [text]}."""
 
-    # TODO(sanyamkapoor): separate train/eval data set.
-    pair_files_glob = os.path.join(data_dir, 'pairs-*.csv')
-    for pairs_file_path in glob.glob(pair_files_glob):
-      with open(pairs_file_path, 'r') as csv_file:
+    pair_csv_files = [
+        generator_utils.maybe_download(data_dir, filename, uri)
+        for uri, filename in self.source_data_files(dataset_split)
+    ]
+
+    for pairs_file in pair_csv_files:
+      with open(pairs_file, 'r') as csv_file:
         pairs_reader = csv.reader(csv_file)
         for row in pairs_reader:
           function_tokens, docstring_tokens = row[-2:]

--- a/code_search/app/code_search/t2t/similarity_transformer.py
+++ b/code_search/app/code_search/t2t/similarity_transformer.py
@@ -16,13 +16,15 @@ class SimilarityTransformer(t2t_model.T2TModel):
   and docstrings
   """
 
+  def top(self, body_output, features):
+    return body_output
+
   def body(self, features):
     """Body of the Similarity Transformer Network."""
 
     with tf.variable_scope('string_embedding'):
       string_embedding = self.encode(features, 'inputs')
 
-    loss = None
     if 'targets' in features:
       with tf.variable_scope('code_embedding'):
         code_embedding = self.encode(features, 'targets')
@@ -45,8 +47,7 @@ class SimilarityTransformer(t2t_model.T2TModel):
       loss = tf.nn.sigmoid_cross_entropy_with_logits(labels=labels,
                                                      logits=logits)
 
-    if loss is not None:
-      return string_embedding, loss
+      return string_embedding, {'training': loss}
 
     return string_embedding
 
@@ -70,3 +71,7 @@ class SimilarityTransformer(t2t_model.T2TModel):
     encoder_output = tf.reduce_mean(tf.squeeze(encoder_output, axis=2), axis=1)
 
     return encoder_output
+
+  def infer(self, features=None, **kwargs):
+    predictions, _ = self(features)
+    return predictions

--- a/code_search/app/code_search/t2t/similarity_transformer.py
+++ b/code_search/app/code_search/t2t/similarity_transformer.py
@@ -16,7 +16,7 @@ class SimilarityTransformer(t2t_model.T2TModel):
   and docstrings
   """
 
-  def top(self, body_output, features):
+  def top(self, body_output, features):  # pylint: disable=no-self-use,unused-argument
     return body_output
 
   def body(self, features):
@@ -72,6 +72,6 @@ class SimilarityTransformer(t2t_model.T2TModel):
 
     return encoder_output
 
-  def infer(self, features=None, **kwargs):
+  def infer(self, features=None, **kwargs):  # pylint: disable=no-self-use,unused-argument
     predictions, _ = self(features)
     return predictions


### PR DESCRIPTION
Fixes #166.

This fixes the Similarity Transformer Model which was earlier failing with `t2t-exporter`. The model export from T2T now works and returns a high-dimensional embedding vector via the RPC call. The interface is exposed from a search server via the `/embed` url.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/169)
<!-- Reviewable:end -->
