### PR TITLE
Fix T2T memory problem

### DIFF
--- a/code_search/src/code_search/dataflow/cli/create_function_embeddings.py
+++ b/code_search/src/code_search/dataflow/cli/create_function_embeddings.py
@@ -17,6 +17,9 @@ def create_function_embeddings(argv=None):
     - See `transforms.github_dataset.GithubBatchPredict` for details of tables created
     - Additionally, store CSV of docstring, original functions and other metadata for
       reverse index lookup during search engine queries.
+
+  NOTE: The number of output file shards have been fixed (at 100) to avoid a large
+  number of output files, making it manageable.
   """
   pipeline_opts = arguments.prepare_pipeline_opts(argv)
   args = pipeline_opts._visible_options  # pylint: disable=protected-access

--- a/code_search/src/code_search/dataflow/cli/create_function_embeddings.py
+++ b/code_search/src/code_search/dataflow/cli/create_function_embeddings.py
@@ -37,7 +37,8 @@ def create_function_embeddings(argv=None):
     | "Format for CSV Write" >> beam.ParDo(dict_to_csv.DictToCSVString(
         ['nwo', 'path', 'function_name', 'lineno', 'original_function', 'function_embedding']))
     | "Write Embeddings to CSV" >> beam.io.WriteToText('{}/func-index'.format(args.data_dir),
-                                                       file_name_suffix='.csv')
+                                                       file_name_suffix='.csv',
+                                                       num_shards=100)
   )
 
   result = pipeline.run()

--- a/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
+++ b/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
@@ -40,7 +40,8 @@ def preprocess_github_dataset(argv=None):
     | "Format for CSV Write" >> beam.ParDo(dict_to_csv.DictToCSVString(
       ['docstring_tokens', 'function_tokens']))
     | "Write CSV" >> beam.io.WriteToText('{}/func-doc-pairs'.format(args.data_dir),
-                                         file_name_suffix='.csv')
+                                         file_name_suffix='.csv',
+                                         num_shards=100)
   )
 
   result = pipeline.run()

--- a/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
+++ b/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
@@ -18,6 +18,9 @@ def preprocess_github_dataset(argv=None):
     - See `transforms.github_dataset.TransformGithubDataset` for details of tables created
     - Additionally, store pairs of docstring and function tokens in a CSV file
       for training
+
+  NOTE: The number of output file shards have been fixed (at 100) to avoid a large
+  number of output files, making it manageable.
   """
   pipeline_opts = arguments.prepare_pipeline_opts(argv)
   args = pipeline_opts._visible_options  # pylint: disable=protected-access

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -18,16 +18,38 @@ class GithubFunctionDocstring(text_problems.Text2TextProblem):
   the docstring tokens and function tokens. The delimiter is
   ",".
   """
-
-  @property
-  def base_url(self):
-    return "gs://kubeflow-examples/t2t-code-search/raw_data"
-
   @property
   def pair_files_list(self):
+    """Return URL and file names.
+
+    This format is a convention across the Tensor2Tensor (T2T)
+    codebase. It should be noted that the file names are currently
+    hardcoded. This is to preserve the semantics of a T2T problem.
+    In case a change of these values is desired, one must subclass
+    and override this property.
+
+    # TODO(sanyamkapoor): Manually separate train/eval data set.
+
+    Returns:
+      A list of the format,
+        [
+          [
+            "STRING",
+            ("STRING", "STRING", ...)
+          ],
+          ...
+        ]
+      Each element is a list of size 2 where the first represents
+      the source URL and the next is an n-tuple of file names.
+
+      In this case, the tuple is of size 1 because the URL points
+      to a file itself.
+    """
+    base_url = "gs://kubeflow-examples/t2t-code-search/raw_data"
+
     return [
         [
-            "{}/func-doc-pairs-000{:02}-of-00100.csv".format(self.base_url, i),
+            "{}/func-doc-pairs-000{:02}-of-00100.csv".format(base_url, i),
             ("func-doc-pairs-000{:02}-of-00100.csv".format(i),)
         ]
         for i in range(100)
@@ -60,12 +82,9 @@ class GithubFunctionDocstring(text_problems.Text2TextProblem):
       Each element yielded is of a Python dict of the form
         {"inputs": "STRING", "targets": "STRING"}
     """
-
-    # TODO(sanyamkapoor): Manually separate train/eval data set.
-    csv_file_names = self.pair_files_list
     csv_files = [
         generator_utils.maybe_download(tmp_dir, file_list[0], uri)
-        for uri, file_list in csv_file_names
+        for uri, file_list in self.pair_files_list
     ]
 
     for pairs_file in csv_files:

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -1,11 +1,18 @@
 """Github function/text similatrity problems."""
-from cStringIO import StringIO
 import csv
+import six
 from tensor2tensor.data_generators import generator_utils
 from tensor2tensor.data_generators import translate
 from tensor2tensor.utils import metrics
 from tensor2tensor.utils import registry
 import tensorflow as tf
+
+# pylint: disable=g-import-not-at-top
+if six.PY2:
+  from StringIO import StringIO
+else:
+  from io import StringIO
+# pylint: enable=g-import-not-at-top
 
 
 @registry.register_problem
@@ -21,12 +28,12 @@ class GithubFunctionDocstring(translate.TranslateProblem):
 
   @property
   def base_url(self):
-    return 'gs://kubeflow-examples/t2t-code-search/raw_data'
+    return "gs://kubeflow-examples/t2t-code-search/raw_data"
 
   @property
   def pair_files_list(self):
     return [
-        'func-doc-pairs-000{:02}-of-00100.csv'.format(i)
+        "func-doc-pairs-000{:02}-of-00100.csv".format(i)
         for i in range(100)
     ]
 
@@ -63,21 +70,20 @@ class GithubFunctionDocstring(translate.TranslateProblem):
     """
 
     csv_file_names = self.source_data_files(dataset_split)
-    download_dir = tmp_dir if data_dir.startswith('gs://') else data_dir
     csv_files = [
-        generator_utils.maybe_download(download_dir, filename,
-                                       '{}/{}'.format(self.base_url,
+        generator_utils.maybe_download(tmp_dir, filename,
+                                       "{}/{}".format(self.base_url,
                                                       filename))
         for filename in csv_file_names
     ]
 
     for pairs_file in csv_files:
-      tf.logging.debug('Reading {}'.format(pairs_file))
-      with open(pairs_file, 'r') as csv_file:
+      tf.logging.debug("Reading {}".format(pairs_file))
+      with open(pairs_file, "r") as csv_file:
         for line in csv_file:
           reader = csv.reader(StringIO(line))
           for docstring_tokens, function_tokens in reader:
-            yield {'inputs': docstring_tokens, 'targets': function_tokens}
+            yield {"inputs": docstring_tokens, "targets": function_tokens}
 
   def eval_metrics(self):  # pylint: disable=no-self-use
     return [

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -7,12 +7,12 @@ from tensor2tensor.utils import metrics
 from tensor2tensor.utils import registry
 import tensorflow as tf
 
-# pylint: disable=g-import-not-at-top
+# pylint: disable-all
 if six.PY2:
   from StringIO import StringIO
 else:
   from io import StringIO
-# pylint: enable=g-import-not-at-top
+# pylint: enable-all
 
 
 @registry.register_problem
@@ -54,7 +54,7 @@ class GithubFunctionDocstring(translate.TranslateProblem):
     # FIXME(sanyamkapoor): This exists to handle memory explosion.
     return int(3.5e5)
 
-  def generate_samples(self, data_dir, tmp_dir, dataset_split):
+  def generate_samples(self, _data_dir, tmp_dir, dataset_split):
     """A generator to return data samples.Returns the data generator to return.
 
 

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -19,12 +19,16 @@ class GithubFunctionDocstring(translate.TranslateProblem):
   ",".
   """
 
-  FILES_BASE_URL = 'gs://kubeflow-examples/t2t-code-search/raw_data'
+  @property
+  def base_url(self):
+    return 'gs://kubeflow-examples/t2t-code-search/raw_data'
 
-  GITHUB_FUNC_DOC_PAIR_FILES = [
-    'func-doc-pairs-000{:02}-of-00100.csv'.format(i)
-    for i in range(100)
-  ]
+  @property
+  def pair_files_list(self):
+    return [
+        'func-doc-pairs-000{:02}-of-00100.csv'.format(i)
+        for i in range(100)
+    ]
 
   @property
   def is_generate_per_split(self):
@@ -36,7 +40,7 @@ class GithubFunctionDocstring(translate.TranslateProblem):
 
   def source_data_files(self, _):
     # TODO(sanyamkapoor): Manually separate train/eval data set.
-    return self.GITHUB_FUNC_DOC_PAIR_FILES
+    return self.pair_files_list
 
   @property
   def max_samples_for_vocab(self):
@@ -62,7 +66,7 @@ class GithubFunctionDocstring(translate.TranslateProblem):
     download_dir = tmp_dir if data_dir.startswith('gs://') else data_dir
     csv_files = [
         generator_utils.maybe_download(download_dir, filename,
-                                       '{}/{}'.format(self.FILES_BASE_URL,
+                                       '{}/{}'.format(self.base_url,
                                                       filename))
         for filename in csv_file_names
     ]

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -33,7 +33,10 @@ class GithubFunctionDocstring(translate.TranslateProblem):
   @property
   def pair_files_list(self):
     return [
-        "func-doc-pairs-000{:02}-of-00100.csv".format(i)
+        [
+            "{}/func-doc-pairs-000{:02}-of-00100.csv".format(self.base_url, i),
+            ("func-doc-pairs-000{:02}-of-00100.csv".format(i),)
+        ]
         for i in range(100)
     ]
 
@@ -71,10 +74,8 @@ class GithubFunctionDocstring(translate.TranslateProblem):
 
     csv_file_names = self.source_data_files(dataset_split)
     csv_files = [
-        generator_utils.maybe_download(tmp_dir, filename,
-                                       "{}/{}".format(self.base_url,
-                                                      filename))
-        for filename in csv_file_names
+        generator_utils.maybe_download(tmp_dir, file_list[0], uri)
+        for uri, file_list in csv_file_names
     ]
 
     for pairs_file in csv_files:

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -1,22 +1,15 @@
 """Github function/text similatrity problems."""
 import csv
-import six
+from six import StringIO
 from tensor2tensor.data_generators import generator_utils
-from tensor2tensor.data_generators import translate
+from tensor2tensor.data_generators import text_problems
 from tensor2tensor.utils import metrics
 from tensor2tensor.utils import registry
 import tensorflow as tf
 
-# pylint: disable-all
-if six.PY2:
-  from StringIO import StringIO
-else:
-  from io import StringIO
-# pylint: enable-all
-
 
 @registry.register_problem
-class GithubFunctionDocstring(translate.TranslateProblem):
+class GithubFunctionDocstring(text_problems.Text2TextProblem):
   """Function and Docstring similarity Problem.
 
   This problem contains the data consisting of function
@@ -48,16 +41,12 @@ class GithubFunctionDocstring(translate.TranslateProblem):
   def approx_vocab_size(self):
     return 2**13
 
-  def source_data_files(self, _):
-    # TODO(sanyamkapoor): Manually separate train/eval data set.
-    return self.pair_files_list
-
   @property
   def max_samples_for_vocab(self):
     # FIXME(sanyamkapoor): This exists to handle memory explosion.
     return int(3.5e5)
 
-  def generate_samples(self, _data_dir, tmp_dir, dataset_split):
+  def generate_samples(self, _data_dir, tmp_dir, _dataset_split):
     """A generator to return data samples.Returns the data generator to return.
 
 
@@ -72,7 +61,8 @@ class GithubFunctionDocstring(translate.TranslateProblem):
         {"inputs": "STRING", "targets": "STRING"}
     """
 
-    csv_file_names = self.source_data_files(dataset_split)
+    # TODO(sanyamkapoor): Manually separate train/eval data set.
+    csv_file_names = self.pair_files_list
     csv_files = [
         generator_utils.maybe_download(tmp_dir, file_list[0], uri)
         for uri, file_list in csv_file_names

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -25,7 +25,12 @@ class GithubFunctionDocstring(translate.TranslateProblem):
   def approx_vocab_size(self):
     return 2**13
 
-  def _get_csv_files(self, data_dir, tmp_dir, dataset_split, limit=None):
+  # FIXME(sanyamkapoor): This exists to handle memory explosion.
+  @property
+  def max_samples_for_vocab(self):
+    return int(3e5)
+
+  def _get_csv_files(self, data_dir, tmp_dir, dataset_split):
     """Get a list of CSV files.
 
     This routine gets the list of CSV files in data_dir. If
@@ -33,23 +38,19 @@ class GithubFunctionDocstring(translate.TranslateProblem):
     into the temporary directory. Optionally, one can limit the
     number of CSV files to process.
 
-    FIXME(sanyamkapoor): `limit` exists to handle memory explosion.
-    TODO(sanyamkapoor): separate train/eval data set.
+    TODO(sanyamkapoor): Manually separate train/eval data set.
 
     Args:
       data_dir: A string representing the data directory.
       tmp_dir: A string representing the temporary directory and is
               used to download files if not already available.
       dataset_split: Unused.
-      limit: Limit the number of CSV files returned.
 
     Returns:
       A list of strings representing the CSV file paths on local filesystem.
     """
     glob_string = '{}/*.csv'.format(data_dir)
     csv_files = tf.gfile.Glob(glob_string)
-    if limit:
-      csv_files = csv_files[:limit]
 
     if os.path.isdir(data_dir):
       return csv_files
@@ -74,7 +75,7 @@ class GithubFunctionDocstring(translate.TranslateProblem):
         {"inputs": "STRING", "targets": "STRING"}
     """
 
-    csv_files = self._get_csv_files(data_dir, tmp_dir, dataset_split, limit=1000)
+    csv_files = self._get_csv_files(data_dir, tmp_dir, dataset_split)
 
     if not csv_files:
       tf.logging.fatal('No CSV files found or downloaded!')

--- a/code_search/src/code_search/t2t/function_docstring.py
+++ b/code_search/src/code_search/t2t/function_docstring.py
@@ -48,7 +48,7 @@ class GithubFunctionDocstring(translate.TranslateProblem):
     return int(3.5e5)
 
   def generate_samples(self, data_dir, tmp_dir, dataset_split):
-    """A generator to return data samples.Returns the data generator to return .
+    """A generator to return data samples.Returns the data generator to return.
 
 
     Args:
@@ -76,8 +76,8 @@ class GithubFunctionDocstring(translate.TranslateProblem):
       with open(pairs_file, 'r') as csv_file:
         for line in csv_file:
           reader = csv.reader(StringIO(line))
-          docstring_tokens, function_tokens = next(reader)
-          yield {'inputs': docstring_tokens, 'targets': function_tokens}
+          for docstring_tokens, function_tokens in reader:
+            yield {'inputs': docstring_tokens, 'targets': function_tokens}
 
   def eval_metrics(self):  # pylint: disable=no-self-use
     return [

--- a/code_search/src/code_search/t2t/similarity_transformer.py
+++ b/code_search/src/code_search/t2t/similarity_transformer.py
@@ -9,19 +9,19 @@ import tensorflow as tf
 
 @registry.register_model
 class SimilarityTransformer(t2t_model.T2TModel):
-  # pylint: disable=abstract-method
+  """Transformer Model for Similarity between two strings.
 
-  """
-  This class defines the model to compute similarity scores between functions
-  and docstrings
+  This model defines the architecture using two transformer
+  networks, each of which embed a string and the loss is
+  calculated as a Binary Cross-Entropy loss. Normalized
+  Dot Product is used as the distance measure between two
+  string embeddings.
   """
 
-  def top(self, body_output, features):  # pylint: disable=no-self-use,unused-argument
+  def top(self, body_output, features):
     return body_output
 
   def body(self, features):
-    """Body of the Similarity Transformer Network."""
-
     with tf.variable_scope('string_embedding'):
       string_embedding = self.encode(features, 'inputs')
 
@@ -57,21 +57,21 @@ class SimilarityTransformer(t2t_model.T2TModel):
 
     (encoder_input, encoder_self_attention_bias, _) = (
         transformer.transformer_prepare_encoder(inputs, problem.SpaceID.EN_TOK,
-                                                self._hparams))
+                                                hparams))
 
     encoder_input = tf.nn.dropout(encoder_input,
                                   1.0 - hparams.layer_prepostprocess_dropout)
     encoder_output = transformer.transformer_encoder(
         encoder_input,
         encoder_self_attention_bias,
-        self._hparams,
+        hparams,
         nonpadding=transformer.features_to_nonpadding(features, input_key))
-    encoder_output = tf.expand_dims(encoder_output, 2)
 
-    encoder_output = tf.reduce_mean(tf.squeeze(encoder_output, axis=2), axis=1)
+    encoder_output = tf.reduce_mean(encoder_output, axis=1)
 
     return encoder_output
 
-  def infer(self, features=None, **kwargs):  # pylint: disable=no-self-use,unused-argument
+  def infer(self, features=None, **kwargs):
+    del kwargs
     predictions, _ = self(features)
     return predictions

--- a/code_search/src/code_search/t2t/similarity_transformer.py
+++ b/code_search/src/code_search/t2t/similarity_transformer.py
@@ -18,7 +18,7 @@ class SimilarityTransformer(t2t_model.T2TModel):
   string embeddings.
   """
 
-  def top(self, body_output, features):
+  def top(self, body_output, _):  # pylint: disable=no-self-use
     return body_output
 
   def body(self, features):


### PR DESCRIPTION
Language problems don't really need to view all the data points but only a fraction of them. As a result, to prevent memory explosion, I've added `max_samples_for_vocab` to a reasonable limit.

- Limit the number of samples for vocab (Fixes #189)
- Update to nicer documentation
- Limit the number of CSV files to 100 to make them manageable (else all the data generates ~3k CSV files)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/205)
<!-- Reviewable:end -->
