### PR TITLE
Update Search Index server spec

### DIFF
--- a/code_search/docker/t2t/build.sh
+++ b/code_search/docker/t2t/build.sh
@@ -8,8 +8,13 @@
 
 set -ex
 
+PROJECT=${PROJECT:-}
 BUILD_IMAGE_UUID=$(python3 -c 'import uuid; print(uuid.uuid4().hex[:7]);')
 BUILD_IMAGE_TAG="code-search:v$(date +%Y%m%d)-${BUILD_IMAGE_UUID}"
+
+if [[ ! -z "${PROJECT}" ]]; then
+  BUILD_IMAGE_TAG="gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}"
+fi
 
 # Directory of this script used for path references
 _SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -29,15 +34,9 @@ docker build -f "${_SCRIPT_DIR}/Dockerfile" \
              "${_SCRIPT_DIR}/../.."
 
 # Push images to GCR Project if available
-PROJECT=${PROJECT:-}
 if [[ ! -z "${PROJECT}" ]]; then
-  # Tag and push CPU image
-  docker tag ${BUILD_IMAGE_TAG} gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}
-  docker push gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}
-
-  # Tag and push GPU image
-  docker tag ${BUILD_IMAGE_TAG}-gpu gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}-gpu
-  docker push gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}-gpu
+  docker push ${BUILD_IMAGE_TAG}
+  docker push ${BUILD_IMAGE_TAG}-gpu
 fi
 
 popd

--- a/code_search/docker/ui/Dockerfile
+++ b/code_search/docker/ui/Dockerfile
@@ -16,6 +16,10 @@ ADD src/ /src
 
 WORKDIR /src
 
+ARG PUBLIC_URL
+
+ENV PUBLIC_URL=$PUBLIC_URL
+
 RUN cd ui && npm i && npm run build && cd ..
 
 EXPOSE 8008

--- a/code_search/docker/ui/build.sh
+++ b/code_search/docker/ui/build.sh
@@ -13,9 +13,14 @@
 
 set -ex
 
+PROJECT=${PROJECT:-}
 BUILD_IMAGE_UUID=$(python3 -c 'import uuid; print(uuid.uuid4().hex[:7]);')
 BUILD_IMAGE_TAG="code-search-ui:v$(date +%Y%m%d)-${BUILD_IMAGE_UUID}"
 PUBLIC_URL=${PUBLIC_URL:-"/code-search"}
+
+if [[ ! -z "${PROJECT}" ]]; then
+  BUILD_IMAGE_TAG="gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}"
+fi
 
 # Directory of this script used for path references
 _SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -27,11 +32,9 @@ docker build -f "${_SCRIPT_DIR}/Dockerfile" \
              --build-arg PUBLIC_URL=${PUBLIC_URL} \
              "${_SCRIPT_DIR}/../.."
 
-# Push image to GCR PROJECT available
-PROJECT=${PROJECT:-}
+# Push images to GCR Project if available
 if [[ ! -z "${PROJECT}" ]]; then
-  docker tag ${BUILD_IMAGE_TAG} gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}
-  docker push gcr.io/${PROJECT}/${BUILD_IMAGE_TAG}
+  docker push ${BUILD_IMAGE_TAG}
 fi
 
 popd

--- a/code_search/docker/ui/build.sh
+++ b/code_search/docker/ui/build.sh
@@ -5,18 +5,27 @@
 # the Code Search UI to Google Container Registry. It automatically tags
 # a unique image for every run.
 #
+# Also note the PUBLIC_URL endpoint which can either be an FQDN or a path
+# prefix to be used for the JS files in the React Application. It defaults
+# to "/code-search" which means the search server will be accessible at
+# https://PUBLIC_HOSTNAME/code-search.
+#
 
 set -ex
 
 BUILD_IMAGE_UUID=$(python3 -c 'import uuid; print(uuid.uuid4().hex[:7]);')
 BUILD_IMAGE_TAG="code-search-ui:v$(date +%Y%m%d)-${BUILD_IMAGE_UUID}"
+PUBLIC_URL=${PUBLIC_URL:-"/code-search"}
 
 # Directory of this script used for path references
 _SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 pushd "${_SCRIPT_DIR}"
 
-docker build -f "${_SCRIPT_DIR}/Dockerfile" -t ${BUILD_IMAGE_TAG} "${_SCRIPT_DIR}/../.."
+docker build -f "${_SCRIPT_DIR}/Dockerfile" \
+             -t ${BUILD_IMAGE_TAG} \
+             --build-arg PUBLIC_URL=${PUBLIC_URL} \
+             "${_SCRIPT_DIR}/../.."
 
 # Push image to GCR PROJECT available
 PROJECT=${PROJECT:-}

--- a/code_search/kubeflow/components/nms.libsonnet
+++ b/code_search/kubeflow/components/nms.libsonnet
@@ -26,6 +26,7 @@ local baseParams = std.extVar("__ksonnet/params").components["nmslib"];
           }
         },
         spec: {
+          restartPolicy: "Never",
           containers: [
             {
               name: params.name,
@@ -36,7 +37,27 @@ local baseParams = std.extVar("__ksonnet/params").components["nmslib"];
                   containerPort: 8008,
                 }
               ],
+              env: [
+                {
+                  name: "GOOGLE_APPLICATION_CREDENTIALS",
+                  value: "/secret/gcp-credentials/user-gcp-sa.json",
+                }
+              ],
+              volumeMounts: [
+                {
+                  mountPath: "/secret/gcp-credentials",
+                  name: "gcp-credentials",
+                },
+              ],
             }
+          ],
+          volumes: [
+            {
+              name: "gcp-credentials",
+              secret: {
+                secretName: "user-gcp-sa",
+              },
+            },
           ],
         },
       },
@@ -87,9 +108,11 @@ local baseParams = std.extVar("__ksonnet/params").components["nmslib"];
     creator:: {
       local creatorParams = params + {
         args: [
-          "nmslib-create",
-          "--data-file=" + params.dataFile,
-          "--index-file=" + params.indexFile,
+          "-m",
+          "code_search.nmslib.cli.create_search_index",
+          "--data_dir=" + params.dataDir,
+          "--lookup_file=" + params.lookupFile,
+          "--index_file=" + params.indexFile,
         ],
       },
 
@@ -101,12 +124,13 @@ local baseParams = std.extVar("__ksonnet/params").components["nmslib"];
     server:: {
       local serverParams = params + {
         args: [
-          "nmslib-serve",
-          "--data-file=" + params.dataFile,
-          "--index-file=" + params.indexFile,
+          "-m",
+          "code_search.nmslib.cli.start_search_server",
           "--problem=" + params.problem,
-          "--data-dir=" + params.dataDir,
-          "--serving-url=" + params.servingUrl,
+          "--data_dir=" + params.dataDir,
+          "--lookup_file=" + params.lookupFile,
+          "--index_file=" + params.indexFile,
+          "--serving_url=" + params.servingUrl,
         ],
       },
 

--- a/code_search/kubeflow/components/params.libsonnet
+++ b/code_search/kubeflow/components/params.libsonnet
@@ -68,27 +68,36 @@
       modelPath: $.global.t2tWorkingDir + "/output/export/Servo",
       modelServerImage: "gcr.io/kubeflow-images-public/tensorflow-serving-1.8:latest",
       cloud: "gcp",
-      gcpCredentialSecretName: "gcp-credentials",
+      gcpCredentialSecretName: "user-gcp-sa",
     },
 
     "nmslib": {
-      name: null,
       replicas: 1,
-      image: "gcr.io/kubeflow-dev/code-search:v20180621-266e689",
+      image: "gcr.io/kubeflow-dev/code-search-ui:v20180803-156710e",
 
-      dataFile: null,
-      indexFile: null,
-      problem: null,
-      dataDir: null,
-      servingUrl: null,
+      problem: "null",
+      dataDir: "null",
+      lookupFile: "null",
+      indexFile: "null",
+      servingUrl: "null",
     },
 
-    "nms-creator": {
-      name: "nms-creator",
+    "search-index-creator": {
+      name: "search-index-creator",
+
+      dataDir: $.global.t2tWorkingDir + "/data",
+      lookupFile: $.global.t2tWorkingDir + "/code_search_index.csv",
+      indexFile: $.global.t2tWorkingDir + "/code_search_index.nmslib",
     },
 
-    "nms-server": {
-      name: "nms-server",
+    "search-index-server": {
+      name: "search-index-server",
+
+      problem: "github_function_docstring",
+      dataDir: $.global.t2tWorkingDir + "/data",
+      lookupFile: $.global.t2tWorkingDir + "/code_search_index.csv",
+      indexFile: $.global.t2tWorkingDir + "/code_search_index.nmslib",
+      servingUrl: "http://localhost:8601",
     },
   },
 }

--- a/code_search/kubeflow/components/params.libsonnet
+++ b/code_search/kubeflow/components/params.libsonnet
@@ -97,7 +97,7 @@
       dataDir: $.global.t2tWorkingDir + "/data",
       lookupFile: $.global.t2tWorkingDir + "/code_search_index.csv",
       indexFile: $.global.t2tWorkingDir + "/code_search_index.nmslib",
-      servingUrl: "http://localhost:8601",
+      servingUrl: "http://t2t-code-search.kubeflow:8000/v1/models/t2t-code-search:predict",
     },
   },
 }

--- a/code_search/kubeflow/components/params.libsonnet
+++ b/code_search/kubeflow/components/params.libsonnet
@@ -73,7 +73,7 @@
 
     "nmslib": {
       replicas: 1,
-      image: "gcr.io/kubeflow-dev/code-search-ui:v20180803-156710e",
+      image: "gcr.io/kubeflow-dev/code-search-ui:v20180806-7b0fcaa",
 
       problem: "null",
       dataDir: "null",

--- a/code_search/kubeflow/components/search-index-creator.jsonnet
+++ b/code_search/kubeflow/components/search-index-creator.jsonnet
@@ -2,6 +2,6 @@ local k = import "k.libsonnet";
 local nms = import "nms.libsonnet";
 
 local env = std.extVar("__ksonnet/environments");
-local params = std.extVar("__ksonnet/params").components["nms-creator"];
+local params = std.extVar("__ksonnet/params").components["search-index-creator"];
 
 std.prune(k.core.v1.list.new(nms.parts(params, env).creator))

--- a/code_search/kubeflow/components/search-index-server.jsonnet
+++ b/code_search/kubeflow/components/search-index-server.jsonnet
@@ -2,6 +2,6 @@ local k = import "k.libsonnet";
 local nms = import "nms.libsonnet";
 
 local env = std.extVar("__ksonnet/environments");
-local params = std.extVar("__ksonnet/params").components["nms-server"];
+local params = std.extVar("__ksonnet/params").components["search-index-server"];
 
 std.prune(k.core.v1.list.new(nms.parts(params, env).server))

--- a/code_search/kubeflow/vendor/kubeflow/tf-serving@e95f94a1a97a0974ada734895d590b5ba565fa77/tf-serving.libsonnet
+++ b/code_search/kubeflow/vendor/kubeflow/tf-serving@e95f94a1a97a0974ada734895d590b5ba565fa77/tf-serving.libsonnet
@@ -122,6 +122,7 @@
       args: [
         "/usr/bin/tensorflow_model_server",
         "--port=9000",
+        "--rest_api_port=8000",
         "--model_name=" + $.params.modelName,
         "--model_base_path=" + $.params.modelPath,
       ],
@@ -342,7 +343,7 @@
   gcpParts:: $.parts {
     gcpEnv:: [
       if $.gcpParams.gcpCredentialSecretName != "" then
-        { name: "GOOGLE_APPLICATION_CREDENTIALS", value: "/secret/gcp-credentials/key.json" },
+        { name: "GOOGLE_APPLICATION_CREDENTIALS", value: "/secret/gcp-credentials/user-gcp-sa.json" },
     ],
 
     tfServingContainer: $.parts.tfServingContainer {

--- a/code_search/src/code_search/nmslib/search_server.py
+++ b/code_search/src/code_search/nmslib/search_server.py
@@ -1,3 +1,4 @@
+import os
 from flask import Flask, request, abort, jsonify, make_response, redirect
 
 
@@ -29,7 +30,8 @@ class CodeSearchServer:
 
     @self.app.route('/')
     def index():
-      return redirect('/index.html', code=302)
+      redirect_path = os.environ.get('PUBLIC_URL', '') + '/index.html'
+      return redirect(redirect_path, code=302)
 
     @self.app.route('/ping')
     def ping():

--- a/code_search/src/ui/src/CodeSearchApi.js
+++ b/code_search/src/ui/src/CodeSearchApi.js
@@ -1,6 +1,6 @@
 import request from 'superagent';
 
-const SEARCH_URL='/query';
+const SEARCH_URL=`${process.env.PUBLIC_URL}/query`;
 
 function code_search_api(str) {
   return request.get(SEARCH_URL).query({'q': str});


### PR DESCRIPTION
- Update Search Index Creator Ksonnet Component
- Update Search Index Server Ksonnet Component
- The Search UI is now deployable on any url path prefix (via a `PUBLIC_URL` environment variable). This is the same environment variable used by the build process.
- Instead of building two image tags (one with the remote `gcr.io` prefix and one without), build just one based on whether `PROJECT` variable is available or not.

/cc @jlewi @ankushagarwal

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/213)
<!-- Reviewable:end -->
