### PR TITLE
Update Ksonnet version, Add Python2 pip

### DIFF
--- a/codelab-image/Dockerfile
+++ b/codelab-image/Dockerfile
@@ -3,13 +3,12 @@
 
 FROM gcr.io/kubeflow-images-public/tensorflow-1.8.0-notebook-cpu
 
-ENV KS_VER ks_0.12.0-rc1_linux_amd64
+ENV KS_VER=0.12.0 KS_ARCH=linux_amd64
 
-RUN cd /tmp && \
-    wget --quiet https://github.com/ksonnet/ksonnet/releases/download/v0.12.0-rc1/$KS_VER.tar.gz && \
-    tar -xvf $KS_VER.tar.gz && \
-    rm $KS_VER.tar.gz
-
-ENV PATH $PATH:/tmp/$KS_VER
+RUN apt-get update && apt-get install -y python-pip &&\
+    curl -LO "https://github.com/ksonnet/ksonnet/releases/download/v${KS_VER}/ks_${KS_VER}_${KS_ARCH}.tar.gz" &&\
+    tar -xvf ks_*.tar.gz && \
+    cp ks_*/ks /usr/local/bin &&\
+    rm -rf ks_*
 
 RUN pip install --no-cache-dir annoy ktext nltk Pillow pydot

--- a/codelab-image/README.md
+++ b/codelab-image/README.md
@@ -2,7 +2,7 @@
 
 This is a Jupyter notebook image intended for Kubeflow codelabs. It is based off the
 public TensorFlow notebook, with the following additional components installed:
-* ksonnet (version 0.12.0-rc1)
+* ksonnet (version 0.12.0)
 * annoy
 * ktext
 * nltk


### PR DESCRIPTION
This PR updates the codelab image.

- Upgrade Ksonnet to stable `0.12.0`.
- Move `ks` binary to standard `/usr/local/bin` path.
- Add `python-pip` package which makes `pip2` available for use with Python2

/cc @jlewi @richardsliu

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/216)
<!-- Reviewable:end -->
