### PR TITLE
Fix #272

### DIFF
--- a/object_detection/ks-app/components/create-pet-record-job.jsonnet
+++ b/object_detection/ks-app/components/create-pet-record-job.jsonnet
@@ -21,7 +21,7 @@ apiVersion: "batch/v1",
           image: params.image,
           imagePullPolicy: "IfNotPresent",
           command: ["python", "/models/research/object_detection/dataset_tools/create_pet_tf_record.py"],
-          args: ["--label_map_path=models/research/object_detection/data/pet_label_map.pbtxt",
+          args: ["--label_map_path=/models/research/object_detection/data/pet_label_map.pbtxt",
                  "--data_dir=" + params.dataDirPath,
                  "--output_dir=" + params.outputDirPath],
           volumeMounts: [{


### PR DESCRIPTION
Fix #272 where the `create-pet-record-job` pod produces this error: `models/research/object_detection/data/pet_label_map.pbtxt; No such file or directory`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/273)
<!-- Reviewable:end -->
