### PR TITLE
Remove inactive reviewers/approvers.

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,9 @@
 # TODO(jlewi): We should probably have OWNERs files in subdirectories that
 # list approvers for individual components (e.g. Seldon folks for Seldon component)
 approvers:
-  - DjangoPeng
   - gaocegege
   - jlewi
   - lluunn
   - texasmichelle
 reviewers:
   - cwbeitel
-  - Jimexist
-  - nkashy1
-  - wbuchwalter
-  - zjj2wry


### PR DESCRIPTION
https://devstats.kubeflow.org/d/46/user-reviews-repository-groups?orgId=1&var-period=d7&var-repo_name=All&var-repo=all&var-reviewers=DjangoPeng&var-reviewers=nkashy1

This will help blunderbuss assign better reviewers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/296)
<!-- Reviewable:end -->
