### PR TITLE
[code search] add flag to wait till code search job finish

### DIFF
--- a/code_search/src/code_search/dataflow/cli/arguments.py
+++ b/code_search/src/code_search/dataflow/cli/arguments.py
@@ -29,6 +29,8 @@ def add_parser_arguments(parser):
                       help='BigQuery dataset for output results')
   additional_args_parser.add_argument('--pre_transformed', action='store_true',
                       help='Use a pre-transformed BigQuery dataset')
+  additional_args_parser.add_argument('--wait_till_finish', action='store_true',
+                      help='Wait till preprocess job to finished')
 
   predict_args_parser = parser.add_argument_group('Batch Prediction Arguments')
   predict_args_parser.add_argument('--problem', metavar='', type=str,

--- a/code_search/src/code_search/dataflow/cli/arguments.py
+++ b/code_search/src/code_search/dataflow/cli/arguments.py
@@ -29,8 +29,8 @@ def add_parser_arguments(parser):
                       help='BigQuery dataset for output results')
   additional_args_parser.add_argument('--pre_transformed', action='store_true',
                       help='Use a pre-transformed BigQuery dataset')
-  additional_args_parser.add_argument('--wait_till_finish', action='store_true',
-                      help='Wait till preprocess job to finished')
+  additional_args_parser.add_argument('--wait_until_finish', action='store_true',
+                      help='Wait until preprocess job is finished')
 
   predict_args_parser = parser.add_argument_group('Batch Prediction Arguments')
   predict_args_parser.add_argument('--problem', metavar='', type=str,

--- a/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
+++ b/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
@@ -48,7 +48,7 @@ def preprocess_github_dataset(argv=None):
   )
 
   result = pipeline.run()
-  if args.wait_till_finish:
+  if args.wait_until_finish:
     result.wait_until_finish()
 
 

--- a/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
+++ b/code_search/src/code_search/dataflow/cli/preprocess_github_dataset.py
@@ -48,7 +48,7 @@ def preprocess_github_dataset(argv=None):
   )
 
   result = pipeline.run()
-  if args.runner == 'DirectRunner':
+  if args.wait_till_finish:
     result.wait_until_finish()
 
 


### PR DESCRIPTION
This would allow caller who invokes this module to wait for the job to finish.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/306)
<!-- Reviewable:end -->
