### PR TITLE
[code search] Allow caller to wait until create function embedding job to finish

### DIFF
--- a/code_search/src/code_search/dataflow/cli/create_function_embeddings.py
+++ b/code_search/src/code_search/dataflow/cli/create_function_embeddings.py
@@ -45,7 +45,7 @@ def create_function_embeddings(argv=None):
   )
 
   result = pipeline.run()
-  if args.runner == 'DirectRunner':
+  if args.wait_until_finish:
     result.wait_until_finish()
 
 


### PR DESCRIPTION
This would allow caller who invokes this module to wait for the job to finish. A follow up PR to https://github.com/kubeflow/examples/pull/306.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/311)
<!-- Reviewable:end -->
