### PR TITLE
Change dataflow default workdir to /src

### DIFF
--- a/code_search/docker/t2t/Dockerfile.dataflow
+++ b/code_search/docker/t2t/Dockerfile.dataflow
@@ -17,6 +17,6 @@ RUN python -m spacy download en
 ADD src/code_search /app/code_search
 ADD src             /src
 
-WORKDIR /app
+WORKDIR /src
 
 ENV PYTHONIOENCODING=utf-8 T2T_USR_DIR=/app/code_search/t2t


### PR DESCRIPTION
Otherwise when I want to execute dataflow code 
```
python2 -m code_search.dataflow.cli.create_function_embeddings \
```
it complains no setup.py

I could workaround by using workingdir option to switch the dir when launching the container, but setting it to default would be more convenient.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/330)
<!-- Reviewable:end -->
