### PR TITLE
Remove ksonnet registry from dockerignore file

### DIFF
--- a/code_search/.dockerignore
+++ b/code_search/.dockerignore
@@ -1,4 +1,3 @@
 **/.git
 **/.DS_Store
 **/node_modules
-**/kubeflow


### PR DESCRIPTION
In order to build a pipeline that can runs ksonnet command, the ksonnet registry need to be containerized.
Remove it from dockerignore to unblock the work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/333)
<!-- Reviewable:end -->
