### PR TITLE
Fix the ksonnet by defining globals.

### DIFF
--- a/code_search/kubeflow/components/params.libsonnet
+++ b/code_search/kubeflow/components/params.libsonnet
@@ -1,5 +1,12 @@
 {
-  global: {},
+  global: {
+    workingDir: "gs://YOUR/WORKING_DIR",
+    dataDir: "gs://YOUR/DATA_DIR",
+    project: "SET_TO_YOUR_PROJECT",
+    // Experiment needs to be set to a value that exists 
+    // otherwise ksonnet will be valid.
+    experiment: "demo-trainer-11-07-dist-sync-gpu",
+  },
   components: {
 
     // TODO(jlewi): t2t-job and t2t-code-search are intended to set values


### PR DESCRIPTION
* The latest changes to the ksonnet components require certain values
  to be defined as defaults.

* This is part of the move away from using a fake component to define
  parameters that should be reused across different modules.

  see #308

* Verify we can run ks show on a new environment and can evaluate the ksonnet.

Fix #353

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/354)
<!-- Reviewable:end -->
