### PR TITLE
parameterize search index job name

### DIFF
--- a/code_search/kubeflow/app.yaml
+++ b/code_search/kubeflow/app.yaml
@@ -8,7 +8,7 @@ environments:
     path: cs_demo
   pipeline:
     destination:
-      namespace: default
+      namespace: kubeflow
       server: https://kubernetes.default
     k8sVersion: v1.9.7
     path: pipeline

--- a/code_search/kubeflow/app.yaml
+++ b/code_search/kubeflow/app.yaml
@@ -6,6 +6,12 @@ environments:
       server: https://35.185.115.154
     k8sVersion: v1.10.9
     path: cs_demo
+  pipeline:
+    destination:
+      namespace: default
+      server: https://kubernetes.default
+    k8sVersion: v1.9.7
+    path: pipeline
 kind: ksonnet.io/app
 libraries:
   examples:

--- a/code_search/kubeflow/components/experiments.libsonnet
+++ b/code_search/kubeflow/components/experiments.libsonnet
@@ -21,4 +21,12 @@
     lookupFile: "gs://code-search-demo/20181104/code-embeddings-index/embedding-to-info.csv",
     indexFile: "gs://code-search-demo/20181104/code-embeddings-index/embeddings.index",
   },
+  "pipeline": {
+    name: "pipeline",
+    project: "code-search-demo",
+
+    problem: "kf_github_function_docstring",
+    // modelBasePath shouldn't have integer in it.
+    modelBasePath: "gs://code-search-demo/models/20181107-dist-sync-gpu/export/",
+  },
 }

--- a/code_search/kubeflow/components/params.libsonnet
+++ b/code_search/kubeflow/components/params.libsonnet
@@ -92,6 +92,8 @@
     },
     "search-index-creator": {
       name: "search-index-creator",
+      jobNameSuffix: "",
+      image: $.components["t2t-job"].dataflowImage,
       dataDir: $.components["t2t-code-search"].workingDir + "/data",
       lookupFile: $.components["t2t-code-search"].workingDir + "/code_search_index.csv",
       indexFile: $.components["t2t-code-search"].workingDir + "/code_search_index.nmslib",

--- a/code_search/kubeflow/components/search-index-creator.jsonnet
+++ b/code_search/kubeflow/components/search-index-creator.jsonnet
@@ -1,13 +1,13 @@
 local k = import "k.libsonnet";
 
 local env = std.extVar("__ksonnet/environments");
-local params = std.extVar("__ksonnet/params").components["search-index-creator"];
+local baseParams = std.extVar("__ksonnet/params").components["search-index-creator"];
 local experiments = import "experiments.libsonnet";
 
-local baseParams = std.extVar("__ksonnet/params").components["submit-code-embeddings-job"];
 local experimentName = baseParams.experiment;
+local jobNameSuffix = baseParams.jobNameSuffix
 local params = baseParams + experiments[experimentName] + {
-  name: experimentName + "-create-search-index",
+  name: experimentName + "-create-search-index-" + jobNameSuffix
 };
 
 local jobSpec = {

--- a/code_search/kubeflow/components/search-index-creator.jsonnet
+++ b/code_search/kubeflow/components/search-index-creator.jsonnet
@@ -5,9 +5,9 @@ local baseParams = std.extVar("__ksonnet/params").components["search-index-creat
 local experiments = import "experiments.libsonnet";
 
 local experimentName = baseParams.experiment;
-local jobNameSuffix = baseParams.jobNameSuffix
+local jobNameSuffix = baseParams.jobNameSuffix;
 local params = baseParams + experiments[experimentName] + {
-  name: experimentName + "-create-search-index-" + jobNameSuffix
+  name: experimentName + "-create-search-index-" + jobNameSuffix,
 };
 
 local jobSpec = {

--- a/code_search/kubeflow/environments/pipeline/globals.libsonnet
+++ b/code_search/kubeflow/environments/pipeline/globals.libsonnet
@@ -1,0 +1,9 @@
+{
+  // Warning: Do not define a global "image" as that will end up overriding
+  // the image parameter for all components. Define more specific names
+  // e.g. "dataflowImage", "trainerCpuImage", "trainerGpuImage",
+  workingDir: "gs://code-search-demo/20181104",
+  dataDir: "gs://code-search-demo/20181104/data",
+  project: "code-search-demo",
+  experiment: "pipeline",
+}

--- a/code_search/kubeflow/environments/pipeline/main.jsonnet
+++ b/code_search/kubeflow/environments/pipeline/main.jsonnet
@@ -1,0 +1,8 @@
+local base = import "base.libsonnet";
+// uncomment if you reference ksonnet-lib
+// local k = import "k.libsonnet";
+
+base + {
+  // Insert user-specified overrides here. For example if a component is named \"nginx-deployment\", you might have something like:\n")
+  // "nginx-deployment"+: k.deployment.mixin.metadata.labels({foo: "bar"})
+}

--- a/code_search/kubeflow/environments/pipeline/params.libsonnet
+++ b/code_search/kubeflow/environments/pipeline/params.libsonnet
@@ -1,0 +1,12 @@
+local params = std.extVar("__ksonnet/params");
+local globals = import "globals.libsonnet";
+local envParams = params + {
+  components +: {
+  },
+};
+
+{
+  components: {
+    [x]: envParams.components[x] + globals, for x in std.objectFields(envParams.components)
+  },
+}


### PR DESCRIPTION
- Add a dedicated environment for pipeline. The search index job name will have format of 
`pipeline-create-search-index-{{workflow-name}}`
- Add jobNameSuffix field
- Fix submit-code-embeddings-job reference in search-index-creator.jsonnet. (introduced by accident?)

This change would ensure when submitting a job from pipeline, pipeline component can specify parameter like
```
ks param set search-index-creator jobNameSuffix {{workflow-name}} --env pipeline2
ks param set search-index-creator lookupFile gs://some/fixed/path/{{workflow-name}}/*.csv  --env pipeline2
ks param set search-index-creator indexFile  gs://some/fixed/path/{{workflow-name}}/*.index --env pipeline2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/358)
<!-- Reviewable:end -->
