### PR TITLE
tf-training-job doesn't complete

### DIFF
--- a/object_detection/docker/Dockerfile.training
+++ b/object_detection/docker/Dockerfile.training
@@ -76,4 +76,4 @@ WORKDIR $MODELS_HOME
 ARG pipeline_config_path
 ARG train_dir
 
-CMD ["python", "$MODELS_HOME/research/object_detection/model_main.py", "--pipeline_config_path=$pipeline_config_path"  "--model_dir=$train_dir"]
+CMD ["python", "$MODELS_HOME/research/object_detection/legacy/train.py", "--pipeline_config_path=$pipeline_config_path"  "--train_dir=$train_dir"]

--- a/object_detection/ks-app/components/get-data-job.jsonnet
+++ b/object_detection/ks-app/components/get-data-job.jsonnet
@@ -17,7 +17,7 @@ local getDataJob(namespace, name, pvc, url, mountPath) = {
               name: "get-data",
               image: "inutano/wget",
               imagePullPolicy: "IfNotPresent",
-              command: ["wget",  url, "-P", mountPath],
+              command: ["wget",  url, "-P", mountPath, "--no-check-certificate"],
               volumeMounts: [{
                   mountPath: mountPath,
                   name: "pets-data",

--- a/object_detection/ks-app/components/tf-training-job.jsonnet
+++ b/object_detection/ks-app/components/tf-training-job.jsonnet
@@ -21,12 +21,12 @@ local tfJobCpu = {
                 workingDir: "/models",
                 command: [
                   "python",
-                  "research/object_detection/model_main.py",
+                  "research/object_detection/legacy/train.py",
                 ],
                 args:[
                   "--alsologtostderr",
                   "--pipeline_config_path=" + params.pipelineConfigPath,
-                  "--model_dir=" + params.trainDir,
+                  "--train_dir=" + params.trainDir,
                 ],
                 image: params.image,
                 imagePullPolicy: "Always",
@@ -52,7 +52,7 @@ local tfJobCpu = {
           },
         },
       },
-      Chief: {
+      Master: {
         replicas: 1,
         template: {
           spec: {
@@ -61,12 +61,12 @@ local tfJobCpu = {
                 workingDir: "/models",
                 command: [
                   "python",
-                  "research/object_detection/model_main.py",
+                  "research/object_detection/legacy/train.py",
                 ],
                 args:[
                   "--alsologtostderr",
                   "--pipeline_config_path=" + params.pipelineConfigPath,
-                  "--model_dir=" + params.trainDir,
+                  "--train_dir=" + params.trainDir,
                 ],
                 image: params.image,
                 imagePullPolicy: "Always",
@@ -101,12 +101,12 @@ local tfJobCpu = {
                 workingDir: "/models",
                 command: [
                   "python",
-                  "research/object_detection/model_main.py",
+                  "research/object_detection/legacy/train.py",
                 ],
                 args:[
                   "--alsologtostderr",
                   "--pipeline_config_path=" + params.pipelineConfigPath,
-                  "--model_dir=" + params.trainDir,
+                  "--train_dir=" + params.trainDir,
                 ],
                 image: params.image,
                 imagePullPolicy: "Always",


### PR DESCRIPTION
In tensorflow/models/research/object_detection/, only
tensorflow/models/research/object_detection/legacy/train.py
supports kubeflow sor far (construct cluster by reading
TF_CONFIG environment var).

Fixes: #277

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/367)
<!-- Reviewable:end -->
