### PR TITLE
Cleanup build directory before code search GCB build

### DIFF
--- a/code_search/Makefile
+++ b/code_search/Makefile
@@ -51,6 +51,7 @@ build: build-cpu build-gpu build-dataflow
 # Build using GCB. This is useful if we are on a slow internet connection
 # and don't want to pull
 build-gcb:
+	rm -rf ./build
 	mkdir  -p build
 	jsonnet ./docker/t2t/build.jsonnet --ext-str gitVersion=$(GIT_VERSION) --ext-str tag=$(TAG) \
 	  > ./build/build.json
@@ -62,6 +63,7 @@ build-gcb:
 		--timeout=3600 ./build
 
 build-ui-gcb:
+	rm -rf ./build
 	mkdir  -p build
 	jsonnet ./docker/ui/build.jsonnet --ext-str gitVersion=$(GIT_VERSION) --ext-str tag=$(TAG) \
 	  > ./build/build.ui.json
@@ -73,6 +75,7 @@ build-ui-gcb:
 		--timeout=3600 ./build
 
 build-ks-gcb:
+	rm -rf ./build
 	mkdir  -p build
 	jsonnet ./docker/ks/build.jsonnet --ext-str gitVersion=$(GIT_VERSION) --ext-str tag=$(TAG) \
 	  > ./build/build.ks.json


### PR DESCRIPTION
The build directory cached the staled deleted files and without cleaning up the folder, those staled files are carried over to the new image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/370)
<!-- Reviewable:end -->
