### PR TITLE
Expose ArgoCD UI behind Ambassador.

### DIFF
--- a/code_search/demo/cs-demo-1103/k8s_specs/argo_cd.yaml
+++ b/code_search/demo/cs-demo-1103/k8s_specs/argo_cd.yaml
@@ -348,7 +348,7 @@ spec:
         - --status-processors
         - "20"
         - --operation-processors
-        - "10"
+        - "10"        
         image: argoproj/argocd-application-controller:v0.10.6
         name: application-controller
       serviceAccountName: application-controller
@@ -402,6 +402,7 @@ spec:
         - /shared/app
         - --repo-server
         - argocd-repo-server:8081
+        - --insecure
         image: argoproj/argocd-server:v0.10.6
         name: argocd-server
         readinessProbe:

--- a/code_search/demo/cs-demo-1103/k8s_specs/argo_cd_ui_mapping.yaml
+++ b/code_search/demo/cs-demo-1103/k8s_specs/argo_cd_ui_mapping.yaml
@@ -1,0 +1,29 @@
+# Ambassador is only monitoring namespace kubeflow
+# so we define another service inside the kubeflow namespace
+# to do the mapping.
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    getambassador.io/config: |-
+      ---
+      apiVersion: ambassador/v0
+      kind:  Mapping
+      name: argo-cd-mapping
+      prefix: /argocd/
+      rewrite: /argocd/
+      service: argocd-server.argocd
+  name: argocd-mapping
+  namespace: kubeflow
+spec:
+  type: ExternalName
+  externalName: argocd-server.argocd.svc.cluster.local
+  ports:
+  - name: http
+    port: 80
+    protocol: TCP
+    targetPort: 8080
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8080


### PR DESCRIPTION
ArgoCD doesn't work behind the proxy yet because of kubeflow/kubeflow#2005

* We need to disable TLS (its handled by ingress) because that leads to
  endless redirects.

* ArgoCD is running in namespace argo-cd but Ambassador is running in a
  different namespace and currently only configured with RBAC to monitor
  a single namespace.

* So we add a service in namespace kubeflow just to define the Ambassador mapping.

Related to:
    kubeflow/kubeflow#2005 Make ArgoCD work with reverse proxy
    kubeflow/kubeflow#1990 Ingress & ArgoCD

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/413)
<!-- Reviewable:end -->
