### PR TITLE
Fix curl command when sending request to seldon-served model on GKE

### DIFF
--- a/xgboost_ames_housing/README.md
+++ b/xgboost_ames_housing/README.md
@@ -193,21 +193,18 @@ curl -H "Content-Type:application/json" \
 
 ```
 {
-  "data": {
-    "names": [
-      "t:0", 
-      "t:1"
-    ], 
-    "tensor": {
-      "shape": [
-        1, 
-        2
-      ], 
-      "values": [
-        97522.359375, 
-        97522.359375
-      ]
+  "meta": {
+    "puid": "8buc4oo78m67716m2vevvgtpap",
+    "tags": {
+    },
+    "routing": {
     }
+  },
+  "data": {
+    "names": ["t:0", "t:1"],
+    "tensor": {
+      "shape": [1, 2],
+      "values": [97522.359375, 97522.359375]
   }
 }
 ```

--- a/xgboost_ames_housing/README.md
+++ b/xgboost_ames_housing/README.md
@@ -186,7 +186,9 @@ kubectl port-forward $(kubectl get pods -n ${NAMESPACE} -l service=ambassador -o
 Now you are ready to send requests on `localhost:8080`
 
 ```
-curl -H "Content-Type: application/x-www-form-urlencoded" -d 'json={"data":{"tensor":{"shape":[1,37],"values":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37]}}}' http://localhost:8080/predict
+curl -H "Content-Type:application/json" \
+  -d '{"data":{"tensor":{"shape":[1,37],"values":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37]}}}' \
+  http://localhost:8080/seldon/xgboost-ames/api/v0.1/predictions
 ```
 
 ```


### PR DESCRIPTION
Original URL gives a `404 page not found` response.

Got the correct end point URL from [Kubeflow Seldon Serving](https://www.kubeflow.org/docs/guides/components/seldon/).
Assuming Ambassador is exposed at `<ambassadorEndpoint>` and with a Seldon deployment name `<deploymentName>`:

A REST endpoint will be exposed at : `http://<ambassadorEndpoint>/seldon/<deploymentName>/api/v0.1/predictions`

Original Content-Type gave following response:
```
{"timestamp":1544272830561,"status":415,"error":"Unsupported Media Type","exception":"org.springframework.web.HttpMediaTypeNotSupportedException","message":"Content type 'application/x-www-form-urlencoded' not supported","path":"/api/v0.1/predictions"}
```
Content-Type changed to `Content-Type:application/json`

Original data gave following response:
```
{
  "code": 201,
  "info": "json={\"data\":{\"tensor\":{\"shape\":[1,37],\"values\":[1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37]}}}",
  "reason": "Invalid JSON",
  "status": "FAILURE"
}
```
Removed `json=` from `curl` data.

Also modified the response output. Response returned with some metadata.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/415)
<!-- Reviewable:end -->
