### PR TITLE
fix bq table dupliation

### DIFF
--- a/code_search/docker/ks/submit_code_embeddings_job.sh
+++ b/code_search/docker/ks/submit_code_embeddings_job.sh
@@ -41,12 +41,9 @@ names=(cluster dataDir functionEmbeddingsBQTable functionEmbeddingsDir modelDir 
 source "${DIR}/parse_arguments.sh"
 source "${DIR}/initialize_kubectl.sh"
 
-# BQ doesn't support dash. Replace with underscore
-functionEmbeddingsBQTable=$(echo "${functionEmbeddingsBQTable}" | tr - _)
-
 # Apply parameters
 ks param set ${component} dataDir ${dataDir} --env ${ksEnvName}
-ks param set ${component} functionEmbeddingsBQTable ${project}:${functionEmbeddingsBQTable} --env ${ksEnvName}
+ks param set ${component} functionEmbeddingsBQTable ${functionEmbeddingsBQTable} --env ${ksEnvName}
 ks param set ${component} functionEmbeddingsDir ${functionEmbeddingsDir} --env ${ksEnvName}
 ks param set ${component} jobNameSuffix ${workflowId} --env ${ksEnvName}
 ks param set ${component} modelDir ${modelDir} --env ${ksEnvName}

--- a/code_search/docker/ks/submit_code_embeddings_job.sh
+++ b/code_search/docker/ks/submit_code_embeddings_job.sh
@@ -41,6 +41,9 @@ names=(cluster dataDir functionEmbeddingsBQTable functionEmbeddingsDir modelDir 
 source "${DIR}/parse_arguments.sh"
 source "${DIR}/initialize_kubectl.sh"
 
+# BQ doesn't support dash. Replace with underscore
+functionEmbeddingsBQTable=$(echo "${functionEmbeddingsBQTable}" | tr - _)
+
 # Apply parameters
 ks param set ${component} dataDir ${dataDir} --env ${ksEnvName}
 ks param set ${component} functionEmbeddingsBQTable ${functionEmbeddingsBQTable} --env ${ksEnvName}

--- a/code_search/docker/ks/submit_code_embeddings_job.sh
+++ b/code_search/docker/ks/submit_code_embeddings_job.sh
@@ -46,7 +46,7 @@ functionEmbeddingsBQTable=$(echo "${functionEmbeddingsBQTable}" | tr - _)
 
 # Apply parameters
 ks param set ${component} dataDir ${dataDir} --env ${ksEnvName}
-ks param set ${component} functionEmbeddingsBQTable ${functionEmbeddingsBQTable} --env ${ksEnvName}
+ks param set ${component} functionEmbeddingsBQTable ${project}:${functionEmbeddingsBQTable} --env ${ksEnvName}
 ks param set ${component} functionEmbeddingsDir ${functionEmbeddingsDir} --env ${ksEnvName}
 ks param set ${component} jobNameSuffix ${workflowId} --env ${ksEnvName}
 ks param set ${component} modelDir ${modelDir} --env ${ksEnvName}

--- a/code_search/pipeline/CodeSearchPipelineNotebook.ipynb
+++ b/code_search/pipeline/CodeSearchPipelineNotebook.ipynb
@@ -47,7 +47,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cs_pipeline import function_embedding_update"
+    "from cs_pipeline import github_code_index_update"
    ]
   },
   {
@@ -74,11 +74,11 @@
    "outputs": [],
    "source": [
     "# Compile it into a tar package.\n",
-    "compiler.Compiler().compile(function_embedding_update, 'function_embedding_update.tar.gz')\n",
+    "compiler.Compiler().compile(github_code_index_update, 'github_code_index_update.tar.gz')\n",
     "\n",
     "# Submit a run.\n",
     "# inputs - experiment id, run name, tarball file\n",
-    "run = client.run_pipeline(exp.id, 'code-search-function-embedding', 'function_embedding_update.tar.gz')"
+    "run = client.run_pipeline(exp.id, 'code-search-index-update', 'github_code_index_update.tar.gz')"
    ]
   }
  ],

--- a/code_search/pipeline/index_update_pipeline.py
+++ b/code_search/pipeline/index_update_pipeline.py
@@ -23,7 +23,7 @@ def dataflow_function_embedding_op(
         working_dir: str,):
   return dsl.ContainerOp(
     name='dataflow_function_embedding',
-    image='gcr.io/kubeflow-examples/code-search/ks:v20181204-ee47a49-dirty-fa8aa3',
+    image='gcr.io/kubeflow-examples/code-search/ks:v20181208-4c97087-dirty-c727db',
     command=['/usr/local/src/submit_code_embeddings_job.sh'],
     arguments=[
       "--cluster=%s" % cluster_name,
@@ -52,7 +52,7 @@ def search_index_creator_op(
   return dsl.ContainerOp(
     # use component name as step name
     name='search_index_creator',
-    image='gcr.io/kubeflow-examples/code-search/ks:v20181204-ee47a49-dirty-fa8aa3',
+    image='gcr.io/kubeflow-examples/code-search/ks:v20181208-4c97087-dirty-c727db',
     command=['/usr/local/src/launch_search_index_creator_job.sh'],
     arguments=[
       '--cluster=%s' % cluster_name,
@@ -77,7 +77,7 @@ def update_index_op(
   return (
     dsl.ContainerOp(
       name='update_index',
-      image='gcr.io/kubeflow-examples/code-search/ks:v20181204-ee47a49-dirty-fa8aa3',
+      image='gcr.io/kubeflow-examples/code-search/ks:v20181208-4c97087-dirty-c727db',
       command=['/usr/local/src/update_index.sh'],
       arguments=[
         '--appDir=%s' % app_dir,
@@ -135,13 +135,12 @@ def function_embedding_update(
   # Can't use workflow name as bq_suffix since BQ table doesn't accept '-' and
   # workflow name is assigned at runtime. Pipeline might need to support
   # replacing characters in workflow name.
-  bq_suffix = uuid.uuid4().hex[:6].upper()
   working_dir = '%s/%s' % (working_dir, workflow_name)
   lookup_file = '%s/code-embeddings-index/embedding-to-info.csv' % working_dir
   index_file = '%s/code-embeddings-index/embeddings.index'% working_dir
   function_embeddings_dir = '%s/%s' % (working_dir, "code_embeddings")
   function_embeddings_bq_table = \
-    '%s:%s.function_embeddings_%s' % (project, target_dataset, bq_suffix)
+    '%s:%s.function_embeddings_%s' % (project, target_dataset, workflow_name)
 
   function_embedding = dataflow_function_embedding_op(
     cluster_name,

--- a/code_search/pipeline/index_update_pipeline.py
+++ b/code_search/pipeline/index_update_pipeline.py
@@ -139,7 +139,7 @@ def function_embedding_update(
   index_file = '%s/code-embeddings-index/embeddings.index'% working_dir
   function_embeddings_dir = '%s/%s' % (working_dir, "code_embeddings")
   function_embeddings_bq_table = \
-    '%s:%s.function_embeddings_%s' % (project, target_dataset, workflow_name)
+    '%s.function_embeddings_%s' % (target_dataset, workflow_name)
 
   function_embedding = dataflow_function_embedding_op(
     cluster_name,

--- a/code_search/pipeline/index_update_pipeline.py
+++ b/code_search/pipeline/index_update_pipeline.py
@@ -22,7 +22,7 @@ def dataflow_function_embedding_op(
         working_dir: str,):
   return dsl.ContainerOp(
     name='dataflow_function_embedding',
-    image='gcr.io/kubeflow-examples/code-search/ks:v20181208-4c97087-dirty-c727db',
+    image='gcr.io/kubeflow-examples/code-search/ks:v20181208-dce92ba-dirty-e7cc9f',
     command=['/usr/local/src/submit_code_embeddings_job.sh'],
     arguments=[
       "--cluster=%s" % cluster_name,
@@ -51,7 +51,7 @@ def search_index_creator_op(
   return dsl.ContainerOp(
     # use component name as step name
     name='search_index_creator',
-    image='gcr.io/kubeflow-examples/code-search/ks:v20181208-4c97087-dirty-c727db',
+    image='gcr.io/kubeflow-examples/code-search/ks:v20181208-dce92ba-dirty-e7cc9f',
     command=['/usr/local/src/launch_search_index_creator_job.sh'],
     arguments=[
       '--cluster=%s' % cluster_name,
@@ -76,7 +76,7 @@ def update_index_op(
   return (
     dsl.ContainerOp(
       name='update_index',
-      image='gcr.io/kubeflow-examples/code-search/ks:v20181208-4c97087-dirty-c727db',
+      image='gcr.io/kubeflow-examples/code-search/ks:v20181208-dce92ba-dirty-e7cc9f',
       command=['/usr/local/src/update_index.sh'],
       arguments=[
         '--appDir=%s' % app_dir,

--- a/code_search/pipeline/index_update_pipeline.py
+++ b/code_search/pipeline/index_update_pipeline.py
@@ -1,7 +1,6 @@
 # Example Pipeline to update code search UI configuration
 # To compile, use Kubeflow Pipelines V0.1.3 SDK or above.
 
-import uuid
 from kubernetes import client as k8s_client
 import kfp.dsl as dsl
 import kfp.gcp as gcp


### PR DESCRIPTION
Without the fix, table name was determined at compile time and would be same for all recurrent runs. The dataflow job will fail with table already exist error.

Since pipeline doesn't support inject unique camel case workflow name yet, manually replace '-' with '_' as a workaround. 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/418)
<!-- Reviewable:end -->
