### PR TITLE
Add pods/logs permission to the jupyter notebook role.

### DIFF
--- a/code_search/demo/cs-demo-1103/ks_app/vendor/kubeflow/core/jupyterhub.libsonnet
+++ b/code_search/demo/cs-demo-1103/ks_app/vendor/kubeflow/core/jupyterhub.libsonnet
@@ -267,6 +267,7 @@
           ],
           resources: [
             "pods",
+            "pods/log",
             "services",
           ],
           verbs: [


### PR DESCRIPTION
* This is needed so that fairing can tail the logs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/419)
<!-- Reviewable:end -->
