### PR TITLE
Update server DNS for ks web app pipeline environment

### DIFF
--- a/code_search/ks-web-app/app.yaml
+++ b/code_search/ks-web-app/app.yaml
@@ -8,7 +8,7 @@ environments:
     path: cs_demo
   pipeline:
     destination:
-      namespace: cs-web-app
+      namespace: kubeflow
       server: https://35.185.115.154
     k8sVersion: v1.10.9
     path: pipeline

--- a/code_search/ks-web-app/app.yaml
+++ b/code_search/ks-web-app/app.yaml
@@ -9,7 +9,7 @@ environments:
   pipeline:
     destination:
       namespace: cs-web-app
-      server: https://kubernetes.default
+      server: https://35.185.115.154
     k8sVersion: v1.10.9
     path: pipeline
 kind: ksonnet.io/app


### PR DESCRIPTION
Without the change, I got an error when configuring argocd: 
InvalidSpecError: cluster 'https://kubernetes.default' has not been configured

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/423)
<!-- Reviewable:end -->
