### PR TITLE
Update the ArgoCD app to use the kubeflow/examples repo

### DIFF
--- a/code_search/demo/cs-demo-1103/web-app-argocd-app.yaml
+++ b/code_search/demo/cs-demo-1103/web-app-argocd-app.yaml
@@ -17,8 +17,8 @@ spec:
     # with the web app components is checked in.
     # repoURL: https://github.com/kubeflow/examples.git
     # targetRevision: HEAD
-    repoURL: https://github.com/jlewi/examples.git
-    targetRevision: cs_demo_argo_cd
+    repoURL: https://github.com/kubeflow/examples.git
+    targetRevision: master
   syncPolicy:
     automated:
       prune: True


### PR DESCRIPTION
* We were using jlewi's fork because PRs hadn't been committed but
  all the relevant PRs have been merged and master is the source of truth.