### PR TITLE
Pushing web-ui and model serve images to gcr.io/kubeflow-examples

### DIFF
--- a/pytorch_mnist/serving/seldon-wrapper/mnistddpserving.py
+++ b/pytorch_mnist/serving/seldon-wrapper/mnistddpserving.py
@@ -24,7 +24,7 @@ from torchvision import transforms
 
 
 class Net(torch.nn.Module):
-  """ Network architecture. """
+  """ Network architecture """
 
   def __init__(self):
     super(Net, self).__init__()

--- a/pytorch_mnist/web-ui/mnist_client.py
+++ b/pytorch_mnist/web-ui/mnist_client.py
@@ -35,10 +35,7 @@ def get_prediction(image, server_host='127.0.0.1', server_port=8080,
   :param server_host: the address of the Seldon server
   :param server_port: the port used by the server
   :param deployment_name: the name of the deployment
-  :param timeout:     the amount of time to wait for a prediction to complete
   :return 0:          the integer predicted in the MNIST image
-  :return 1:          the confidence scores for all classes
-  :return 2:          the version number of the model handling the request
   """
 
   try:


### PR DESCRIPTION
Fixed some outdated comments to trigger pushing web-ui and model serve images to gcr.io/kubeflow-examples with post-submit job.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/444)
<!-- Reviewable:end -->
