### PR TITLE
Update pytorch_mnist example to use v1beta1

### DIFF
--- a/pytorch_mnist/02_distributed_training.md
+++ b/pytorch_mnist/02_distributed_training.md
@@ -21,8 +21,8 @@ Since this is a strong scaling example, we should perform an average after the a
 Deploy the PyTorchJob resource to start training the CPU & GPU models:
 
 ```
-kubectl create -f training/ddp/mnist/cpu/v1alpha2/job_mnist_DDP_CPU.yaml
-kubectl create -f training/ddp/mnist/cpu/v1alpha2/job_mnist_DDP_GPU.yaml
+kubectl create -f training/ddp/mnist/cpu/v1beta1/job_mnist_DDP_CPU.yaml
+kubectl create -f training/ddp/mnist/cpu/v1beta1/job_mnist_DDP_GPU.yaml
 
 ```
 
@@ -31,7 +31,7 @@ kubectl create -f training/ddp/mnist/cpu/v1alpha2/job_mnist_DDP_GPU.yaml
 With the commands above we have created Custom Resource that has been defined and enabled during Kubeflow
 installation, namely `PyTorchJob`.
 
-If you look at [job_mnist_DDP_GPU.yaml](https://github.com/kubeflow/examples/blob/master/github_issue_summarization/training/ddp/mnist/cpu/v1alpha2/job_mnist_DDP_GPU.yaml) few things are worth mentioning.
+If you look at [job_mnist_DDP_GPU.yaml](https://github.com/kubeflow/examples/blob/master/github_issue_summarization/training/ddp/mnist/cpu/v1beta1/job_mnist_DDP_GPU.yaml) few things are worth mentioning.
 
 1. We mount our shared persistent disk as /mnt/kubeflow-gcfs for our PyTorchJob, where models will be saved at the end of the epochs
 2. Allocate one GPU to our container

--- a/pytorch_mnist/training/ddp/mnist/gpu/v1beta1/job_mnist_DDP_GPU.yaml
+++ b/pytorch_mnist/training/ddp/mnist/gpu/v1beta1/job_mnist_DDP_GPU.yaml
@@ -1,0 +1,46 @@
+apiVersion: "kubeflow.org/v1beta1"
+kind: "PyTorchJob"
+metadata:
+  name: "pytorch-mnist-ddp-gpu"
+spec:
+  pytorchReplicaSpecs:
+    Master:
+      replicas: 1
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: gcr.io/kubeflow-examples/pytorch-mnist-ddp-gpu
+              volumeMounts:
+              - mountPath: /mnt/kubeflow-gcfs
+                name: kubeflow-gcfs
+              resources:
+                limits:
+                  nvidia.com/gpu: 1
+          volumes:
+            - name: kubeflow-gcfs
+              persistentVolumeClaim:
+                claimName: kubeflow-gcfs
+                readOnly: false
+
+    Worker:
+      replicas: 3
+      restartPolicy: OnFailure
+      template:
+        spec:
+          containers:
+            - name: pytorch
+              image: gcr.io/kubeflow-examples/pytorch-mnist-ddp-gpu
+              volumeMounts:
+              - mountPath: /mnt/kubeflow-gcfs
+                name: kubeflow-gcfs
+              resources: 
+                limits:
+                  nvidia.com/gpu: 1
+          volumes:
+            - name: kubeflow-gcfs
+              persistentVolumeClaim:
+                claimName: kubeflow-gcfs
+                readOnly: false
+


### PR DESCRIPTION
Currently if we deploy kubeflow from HEAD, tf operator is default at v1beta1.  Updating example here to match with it.