### PR TITLE
Build images for xgboost-ames-housing

### DIFF
--- a/xgboost_ames_housing/test/Dockerfile.ubuntu-s2i
+++ b/xgboost_ames_housing/test/Dockerfile.ubuntu-s2i
@@ -1,0 +1,15 @@
+# This file builds an docker image that has source-to-image tool `s2i` installed
+
+FROM ubuntu:xenial
+
+Run set -ex && \
+    apt-get update -yqq && \
+    apt-get install -yqq --no-install-recommends \
+    wget \
+    ca-certificates
+
+# Install s2i
+RUN cd /tmp && \
+    wget -O s2i.tar.gz https://github.com/openshift/source-to-image/releases/download/v1.1.13/source-to-image-v1.1.13-b54d75d3-linux-amd64.tar.gz && \
+    tar -xvf s2i.tar.gz && \
+    mv ./s2i /usr/local/bin

--- a/xgboost_ames_housing/test/Makefile
+++ b/xgboost_ames_housing/test/Makefile
@@ -1,0 +1,52 @@
+# Makefile for building images
+#
+# To override variables do
+# make ${TARGET} ${VAR}=${VALUE}
+#
+# Examples:
+# make build-s2i-image IMG=gcr.io/kubeflow-examples/xgboost_ames_housing_s2i TAG=test
+# make build-seldon-image IMG=gcr.io/kubeflow-examples/xgboost_ames_housing_seldon TAG=latest SOURCE=../seldon_serve
+
+# List any changed  files. We only include files in the notebooks directory.
+# because that is the code in the docker image.
+# In particular we exclude changes to the ksonnet configs.
+CHANGED_FILES := $(shell git diff-files --relative=code_search)
+
+ifeq ($(strip $(CHANGED_FILES)),)
+# Changed files is empty; not dirty
+# Don't include --dirty because it could be dirty if files outside the ones we care
+# about changed.
+GIT_VERSION := $(shell git log --pretty=format:'%h' -n 1)
+else
+GIT_VERSION := $(shell git log --pretty=format:'%h' -n 1)-dirty-$(shell git diff | shasum -a256 | cut -c -6)
+endif
+
+# Build a image which contains source-to-image tool used by seldon for making
+# image to serve models. This image should be stable and doesn't need to
+# rebuild often.
+build-s2i-image:IMG?=gcr.io/kubeflow-examples/xgboost_ames_housing_s2i
+build-s2i-image:TAG?=latest
+build-s2i-image:
+	@echo IMG=$(IMG)
+	@echo GIT_VERSION=$(GIT_VERSION)
+	@echo TAG=$(TAG)
+	docker build -f "./Dockerfile.ubuntu-s2i" \
+             -t $(IMG):$(TAG) \
+             --label=git-versions=$(GIT_VERSION) \
+             ./
+	@echo Built $(IMG):$(TAG)
+
+# Build a serving image in a s2i image, which can be built in the above step.
+build-seldon-image:IMG?=gcr.io/kubeflow-examples/xgboost_ames_housing_seldon
+build-seldon-image:TAG?=latest
+build-seldon-image:SOURCE=../seldon_serve
+build-seldon-image:
+	@echo IMG=$(IMG)
+	@echo GIT_VERSION=$(GIT_VERSION)
+	@echo TAG=$(TAG)
+	@echo SOURCE=$(SOURCE)
+	gcloud builds submit \
+		--config seldon-image-build.yaml \
+		--substitutions=_IMG=$(IMG),TAG_NAME=$(TAG),_GIT_VERSION=$(GIT_VERSION) \
+		$(SOURCE)
+	@echo Built $(IMG):$(TAG)

--- a/xgboost_ames_housing/test/seldon-image-build.yaml
+++ b/xgboost_ames_housing/test/seldon-image-build.yaml
@@ -1,0 +1,8 @@
+steps:
+- name: 'gcr.io/kubeflow-examples/xgboost_ames_housing_s2i:latest'
+  args: ['s2i', 'build', '.', 'seldonio/seldon-core-s2i-python2:0.4', '${_IMG}:$TAG_NAME', '--loglevel=3']
+timeout: 600s
+images:
+    - '${_IMG}:$TAG_NAME'
+tags:
+    - 'GIT-VERSION-${_GIT_VERSION}'


### PR DESCRIPTION
This PR adds configs and makefile for building a seldon serving image via GCB, which will be part of the e2e test for the housing xgboost example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/484)
<!-- Reviewable:end -->
