### PR TITLE
Add support for AWS access/secret keys in the train component (#466)

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -307,9 +307,6 @@ kubectl logs mnist-train-dist-chief-0
 
 #### Using S3
 
-**Note** This example isn't working on S3 yet. There is an open issue [#466](https://github.com/kubeflow/examples/issues/466) 
-to fix that.
-
 To use S3 we need we need to configure TensorFlow to use S3 credentials and variables. These credentials will be provided as kubernetes secrets, and the variables will be passed in as environment variables. Modify the below values to suit your environment.
 
 Give the job a different name (to distinguish it from your job which didn't use GCS)

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -354,47 +354,50 @@ various environment variables configuring access to S3.
        --from-literal=awsSecretAccessKey=${AWS_SECRET_ACCESS_KEY}
      ```
   
-  1. Mount the secret into the pod
+  1. Pass secrets as environment variables into pod
 
      ```
-     ks param set --env=${KSENV} train secret aws-creds=/var/secrets
+     ks param set --env=${KSENV} train secretKeyRefs AWS_ACCESS_KEY_ID=aws-creds.awsAccessKeyID,AWS_SECRET_ACCESS_KEY=aws-creds.awsSecretAccessKey
      ```
 
-     * Setting this ksonnet parameter causes a volumeMount and volume to be added to your TFJob
+     * Setting this ksonnet parameter causes a two new environment variables to be added to your TFJob
      * To see this you can run
 
        ```
        ks show ${KSENV} -c train
        ```
 
-     * The output should now include a volumeMount and volume section
+     * The output should now include two environment variables referencing K8s secret
 
        ```
-apiVersion: kubeflow.org/v1beta1
-kind: TFJob
-metadata:
-  ...
-spec:
-  tfReplicaSpecs:
-    Chief:
-      ...
-      template:
+        apiVersion: kubeflow.org/v1beta1
+        kind: TFJob
+        metadata:
         ...
         spec:
-          containers:
-          - command:
+          tfReplicaSpecs:
+            Chief:
             ...
-            volumeMounts:
-            - mountPath: /var/secrets
-              name: aws-creds
-              readOnly: true
+            template:
             ...
-          volumes:
-          - name: aws-creds
-            secret:
-              secretName: aws-creds
-       ...
-       ```
+            spec:
+              containers:
+              - command:
+              ...
+                env:
+                ...
+                - name: AWS_ACCESS_KEY_ID
+                  valueFrom:
+                    secretKeyRef:
+                      key: awsAccessKeyID
+                      name: aws-creds
+                - name: AWS_SECRET_ACCESS_KEY
+                  valueFrom:
+                    secretKeyRef:
+                      key: awsSecretAccessKey
+                      name: aws-creds
+                      ...
+      ```
   
   1. Next we need to set a whole bunch of S3 related environment variables so that TensorFlow
      knows how to talk to S3

--- a/mnist/ks_app/components/params.libsonnet
+++ b/mnist/ks_app/components/params.libsonnet
@@ -12,6 +12,7 @@
       numPs: 0,
       numWorkers: 0,
       secret: '',
+      secretKeyRefs: '',
       trainSteps: 200,
     },
     "mnist-deploy-gcp": {

--- a/mnist/ks_app/components/train.jsonnet
+++ b/mnist/ks_app/components/train.jsonnet
@@ -44,26 +44,7 @@ local trainEnv = [
 ];
 
 // AWS Access/Secret keys
-local awsSecretKeyRefs = util.parseSecret(params.secretKeyRefs);
-local awsAccessKeyId = if std.length(awsSecretKeyRefs) > 0 then awsSecretKeyRefs[0] else "";
-local awsSecretAccessKey = if std.length(awsSecretKeyRefs) > 1 then awsSecretKeyRefs[1] else "";
-
-local awsEnv = [
-  {
-    name: "AWS_ACCESS_KEY_ID",
-    valueFrom: {
-      secretKeyRef:  
-        awsAccessKeyId
-    }
-  },
-  {
-    name: "AWS_SECRET_ACCESS_KEY",
-    valueFrom: {
-      secretKeyRef:
-        awsSecretAccessKey
-    }
-  }
-];
+local trainSecrets = util.parseSecrets(params.secretKeyRefs);
 
 local secretPieces = std.split(params.secret, "=");
 local secretName = if std.length(secretPieces) > 0 then secretPieces[0] else "";
@@ -76,7 +57,7 @@ local replicaSpec = {
         "/usr/bin/python",
         "/opt/model.py",
       ],
-      env: trainEnv + util.parseEnv(params.envVariables) + awsEnv,
+      env: trainEnv + util.parseEnv(params.envVariables) + trainSecrets,
       image: params.image,
       name: "tensorflow",
       volumeMounts: if secretMountPath != "" then

--- a/mnist/ks_app/components/util.libsonnet
+++ b/mnist/ks_app/components/util.libsonnet
@@ -7,12 +7,29 @@
       value: v[1],
     },
 
+  // convert a list of two items into a map representing a secret name and key
+  listToSecretMap:: function(v)
+    {
+      name: v[0],
+      key: v[1],
+    },
+
   // Function to turn comma separated list of environment variables into a dictionary.
   parseEnv:: function(v)
     local pieces = std.split(v, ",");
     if v != "" && std.length(pieces) > 0 then
       std.map(
         function(i) $.listToMap(std.split(i, "=")),
+        std.split(v, ",")
+      )
+    else [],
+
+  // Function to turn comma separated list of secret names and keys into a dictionary.
+  parseSecret:: function(v)
+    local pieces = std.split(v, ",");
+    if v != "" && std.length(pieces) > 0 then
+      std.map(
+        function(i) $.listToSecretMap(std.split(i, ".")),
         std.split(v, ",")
       )
     else [],

--- a/mnist/ks_app/components/util.libsonnet
+++ b/mnist/ks_app/components/util.libsonnet
@@ -7,11 +7,16 @@
       value: v[1],
     },
 
-  // convert a list of two items into a map representing a secret name and key
+  // convert a list of two items into a map representing an env variable referencing k8s secret
   listToSecretMap:: function(v)
     {
       name: v[0],
-      key: v[1],
+        valueFrom: {
+          secretKeyRef: {
+            name: std.split(v[1], ".")[0],
+            key: std.split(v[1], ".")[1],
+          }
+        }
     },
 
   // Function to turn comma separated list of environment variables into a dictionary.
@@ -24,12 +29,12 @@
       )
     else [],
 
-  // Function to turn comma separated list of secret names and keys into a dictionary.
-  parseSecret:: function(v)
+  // Function to turn comma separated list of env variables referencing secrets into a dictionary.
+  parseSecrets:: function(v)
     local pieces = std.split(v, ",");
     if v != "" && std.length(pieces) > 0 then
       std.map(
-        function(i) $.listToSecretMap(std.split(i, ".")),
+        function(i) $.listToSecretMap(std.split(i, "=")),
         std.split(v, ",")
       )
     else [],


### PR DESCRIPTION
Adding support for AWS access/secret keys as a kubernetes secrets only for the "train" component for a start.

```
ks param set --env=${KSENV} train secretKeyRefs=aws-creds.awsAccessKeyId,aws-creds.awsSecretAccessKey
```

Related to #466 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/488)
<!-- Reviewable:end -->
