### PR TITLE
Fixes #497

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,6 @@ You can find the demos in the [`/demos` directory](demos/).
 
 ## Get Involved
 
-* [Slack Channel: #kubeflow-examples](https://join.slack.com/t/kubeflow/shared_invite/enQtMjgyMzMxNDgyMTQ5LWUwMTIxNmZlZTk2NGU0MmFiNDE4YWJiMzFiOGNkZGZjZmRlNTExNmUwMmQ2NzMwYzk5YzQxOWQyODBlZGY2OTg)
 * [Twitter](http://twitter.com/kubeflow)
 * [Mailing List](https://groups.google.com/forum/#!forum/kubeflow-discuss)
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ You can find the demos in the [`/demos` directory](demos/).
 
 ## Get Involved
 
+* [Slack](https://join.slack.com/t/kubeflow/shared_invite/enQtNDg5MTM4NTQyNjczLWUyZGI1ZmExZWExYWY4YzlkOWI4NjljNjJhZjhjMjEwNGFjNmVkNjg2NTg4M2I0ZTM5NDExZWI5YTIyMzVmNzM)
 * [Twitter](http://twitter.com/kubeflow)
 * [Mailing List](https://groups.google.com/forum/#!forum/kubeflow-discuss)
 


### PR DESCRIPTION
  - Removes slack invite link

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/498)
<!-- Reviewable:end -->
