### PR TITLE
Fixed typo in README and one bad link

### DIFF
--- a/pytorch_mnist/02_distributed_training.md
+++ b/pytorch_mnist/02_distributed_training.md
@@ -39,7 +39,7 @@ kubectl create -f training/ddp/mnist/cpu/v1beta1/job_mnist_DDP_GPU.yaml
 With the commands above we have created Custom Resource that has been defined and enabled during Kubeflow
 installation, namely `PyTorchJob`.
 
-If you look at [job_mnist_DDP_GPU.yaml](https://github.com/kubeflow/examples/blob/master/github_issue_summarization/training/ddp/mnist/cpu/v1beta1/job_mnist_DDP_GPU.yaml) few things are worth mentioning.
+If you look at [job_mnist_DDP_GPU.yaml](https://github.com/kubeflow/examples/blob/master/pytorch_mnist/training/ddp/mnist/gpu/v1beta1/job_mnist_DDP_GPU.yaml) few things are worth mentioning.
 
 1. We mount our shared persistent disk as /mnt/kubeflow-gcfs for our PyTorchJob, where models will be saved at the end of the epochs
 2. Allocate one GPU to our container

--- a/pytorch_mnist/README.md
+++ b/pytorch_mnist/README.md
@@ -32,9 +32,9 @@ In other words, you send an image to the model, and the model does its best to i
 
 ![](https://www.kubeflow.org/docs/images/gcp-e2e-ui-prediction.png)
 
-In the above screenshot, the image shows a hand-written 8. 
+In the above screenshot, the image shows a hand-written 7. 
 The table below the image shows a bar graph for each classification label from 0 to 9. Each bar represents the probability that the image matches the respective label. 
-Looks like it’s pretty confident this one is an 8!
+Looks like it’s pretty confident this one is an 7!
 
 ## Steps:
 


### PR DESCRIPTION
Two small fixes I ran into when trying the example. One is a typo, it says it's displaying an 8 when it is a 7.  The other was a bad link in 02_distributed_training.md

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/508)
<!-- Reviewable:end -->
