### PR TITLE
Trigger tests to print out logs of mnist trainning

### DIFF
--- a/mnist/ks_app/components/train.jsonnet
+++ b/mnist/ks_app/components/train.jsonnet
@@ -1,6 +1,6 @@
 // Component to train a model.
 //
-// Parameters are used to control training
+// Parameters are used to control the training
 //   image: Docker iamge to use
 //   modelDir: Location to write the model this can be a local path (e.g. to a PV)
 //             or it can be any filesystem URI that TF understands (e.g GCS, S3, HDFS)


### PR DESCRIPTION
Due to the problem in the mnist training steps of kubeflow-examples-presubmit tests, and without logs. I just just send the PR to have a try, and trigger some tests to print out the related error logs. Thanks.

The PR updated ` mnist/ks_app/components/train.jsonnet` by adding a `the` in description to trigger the training tests. and updated `mnist/testing/tfjob_test.py` to printed error logs of the tfjobs related pod for debugging.

/do-not-merge

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/516)
<!-- Reviewable:end -->
