### PR TITLE
update TFJob version to v1beta2

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -295,7 +295,7 @@ To use this service account we perform the following steps
         kustomize build .
        ```
        ```
-        apiVersion: kubeflow.org/v1beta1
+        apiVersion: kubeflow.org/v1beta2
         kind: TFJob
         metadata:
           ...
@@ -425,7 +425,7 @@ In order to write to S3 we need to supply the TensorFlow code with AWS credentia
        ```
         kustomize build .
 
-        apiVersion: kubeflow.org/v1beta1
+        apiVersion: kubeflow.org/v1beta2
         kind: TFJob
         metadata:
           ...

--- a/mnist/training/GCS/kustomization.yaml
+++ b/mnist/training/GCS/kustomization.yaml
@@ -45,4 +45,4 @@ patchesJson6902:
     group: kubeflow.org
     kind: TFJob
     name: $(trainingName)
-    version: v1beta1
+    version: v1beta2

--- a/mnist/training/S3/kustomization.yaml
+++ b/mnist/training/S3/kustomization.yaml
@@ -87,4 +87,4 @@ patchesJson6902:
     group: kubeflow.org
     kind: TFJob
     name: $(trainingName)
-    version: v1beta1
+    version: v1beta2

--- a/mnist/training/base/Chief.yaml
+++ b/mnist/training/base/Chief.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeflow.org/v1beta1
+apiVersion: kubeflow.org/v1beta2
 kind: TFJob
 metadata:
   name: $(trainingName)

--- a/mnist/training/base/Ps.yaml
+++ b/mnist/training/base/Ps.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeflow.org/v1beta1
+apiVersion: kubeflow.org/v1beta2
 kind: TFJob
 metadata:
   name: $(trainingName)

--- a/mnist/training/base/Worker.yaml
+++ b/mnist/training/base/Worker.yaml
@@ -1,4 +1,4 @@
-apiVersion: kubeflow.org/v1beta1
+apiVersion: kubeflow.org/v1beta2
 kind: TFJob
 metadata:
   name: $(trainingName)

--- a/mnist/training/base/definition.sh
+++ b/mnist/training/base/definition.sh
@@ -40,7 +40,7 @@ if [ "x${numPs}" != "x" ]; then
 \     group: kubeflow.org \
 \     kind: TFJob \
 \     name: \$(trainingName) \
-\     version: v1beta1 \
+\     version: v1beta2 \
 \      
 ' kustomization.yaml
   else
@@ -59,7 +59,7 @@ if [ "x${numWorkers}" != "x" ]; then
 \     group: kubeflow.org \
 \     kind: TFJob \
 \     name: \$(trainingName) \
-\     version: v1beta1 \
+\     version: v1beta2 \
 \      
 ' kustomization.yaml
   else

--- a/mnist/training/local/kustomization.yaml
+++ b/mnist/training/local/kustomization.yaml
@@ -38,4 +38,4 @@ patchesJson6902:
     group: kubeflow.org
     kind: TFJob
     name: $(trainingName)
-    version: v1beta1
+    version: v1beta2


### PR DESCRIPTION
fixes: #567 

Since the `TFJob` version has been upgraded in the last `kubeflow`, we need to update the `TFJob` version in the mnist example.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/568)
<!-- Reviewable:end -->
