### PR TITLE
MNIST: Update web-ui reference for GCS

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -742,7 +742,7 @@ POD_NAME=$(kubectl get pods --selector=app=web-ui --template '{{range .items}}{{
 kubectl port-forward ${POD_NAME} 8080:5000  
 ```
 
-You should now be able to open up the web app at Local Storage: [http://localhost:8080](http://localhost:8080) and GCS: [http://localhost:8080/?addr=mnist-gcs-dist](http://localhost:8080/?addr=mnist-gcs-dist)
+You should now be able to open up the web app at your localhost. [Local Storage](http://localhost:8080) or [GCS](http://localhost:8080/?addr=mnist-gcs-dist).
 
 
 ### Using IAP on GCP

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -742,7 +742,8 @@ POD_NAME=$(kubectl get pods --selector=app=web-ui --template '{{range .items}}{{
 kubectl port-forward ${POD_NAME} 8080:5000  
 ```
 
-You should now be able to open up the web app at [http://localhost:8080](http://localhost:8080).
+You should now be able to open up the web app at Local Storage: [http://localhost:8080](http://localhost:8080) and GCS: [http://localhost:8080/?addr=mnist-gcs-dist](http://localhost:8080/?addr=mnist-gcs-dist)
+
 
 ### Using IAP on GCP
 


### PR DESCRIPTION
This PR includes small web-ui url fix for GCS.

While trying out steps for `GCS`, after deploying `Web Front End`, tried accessing http://localhost:8080.  Saw below error

```
❗ Exception making request: <_Rendezvous of RPC that terminated with: status = StatusCode.UNAVAILABLE details = "Name resolution failure" debug_error_string = "{"created":"@1559853964.265189614","description":"Failed to create subchannel","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":2706,"referenced_errors":[{"created":"@1559853964.265185059","description":"Name resolution failure","file":"src/core/ext/filters/client_channel/client_channel.cc","file_line":3035,"grpc_status":14}]}" >
```

This is because by default `addr=mnist-service` which works fine for Local Storage. To make it work for GCS i had to modify url to `http://localhost:8080/?addr=mnist-gcs-dist`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/570)
<!-- Reviewable:end -->
