### PR TITLE
fix: update kfp version

### DIFF
--- a/pipelines/mnist-pipelines/requirements.txt
+++ b/pipelines/mnist-pipelines/requirements.txt
@@ -1,3 +1,3 @@
 python-dateutil
-https://storage.googleapis.com/ml-pipeline/release/0.1.9/kfp.tar.gz
+https://storage.googleapis.com/ml-pipeline/release/0.1.22/kfp.tar.gz
 kubernetes==8.0.0


### PR DESCRIPTION
```kfp.onprem``` doesn't exist in version 0.1.9.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/576)
<!-- Reviewable:end -->
