### PR TITLE
recomment using kustomize v2.0.3 for mnist

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -50,6 +50,8 @@ You also need the following command line tools:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [kustomize](https://kustomize.io/)
 
++**Note:** kustomize [v2.0.3](https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3) is recommented since the [problem](https://github.com/kubernetes-sigs/kustomize/issues/1295) in kustomize v2.1.0.
+
 To run the client at the end of the example, you must have [requirements.txt](requirements.txt) installed in your active python environment.
 
 ```

--- a/test/workflows/components/mnist.jsonnet
+++ b/test/workflows/components/mnist.jsonnet
@@ -20,7 +20,7 @@ local defaultParams = {
   // Which Kubeflow cluster to use for running TFJobs on.
   kfProject: "kubeflow-ci-deployment",
   kfZone: "us-east1-b",
-  kfCluster: "kf-v0-5-n04",
+  kfCluster: "kf-vmaster-n01",
 
   // The bucket where the model should be written
   // This needs to be writable by the GCP service account in the Kubeflow cluster (not the test cluster)


### PR DESCRIPTION
Recently someones hit one problem while running mnist example with new kustomize (v2.1.0), such as #583 and #578,  after checked the problem, I think that's should be a issue in new kustomize, logged [ticket](https://github.com/kubernetes-sigs/kustomize/issues/1295) to trace in kustomize.

But avoid user stepping on the pit, the PR is to add note to recomment user to use kustomize 2.0.3. May enhance later if the kustomzie issue fixed.

fixes: #583 #578

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/584)
<!-- Reviewable:end -->
