### PR TITLE
remove useless requirements.txt from mnist

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -50,15 +50,8 @@ You also need the following command line tools:
 - [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
 - [kustomize](https://kustomize.io/)
 
-+**Note:** kustomize [v2.0.3](https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3) is recommented since the [problem](https://github.com/kubernetes-sigs/kustomize/issues/1295) in kustomize v2.1.0.
+**Note:** kustomize [v2.0.3](https://github.com/kubernetes-sigs/kustomize/releases/tag/v2.0.3) is recommented since the [problem](https://github.com/kubernetes-sigs/kustomize/issues/1295) in kustomize v2.1.0.
 
-To run the client at the end of the example, you must have [requirements.txt](requirements.txt) installed in your active python environment.
-
-```
-pip install -r requirements.txt
-```
-
-NOTE: These instructions rely on Github, and may cause issues if behind a firewall with many Github users. 
 
 ## Modifying existing examples
 

--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,6 +1,0 @@
-grpc==0.3.post19
-numpy==1.14.0
-Pillow==5.0.0
-python-mnist==0.5
-tensorflow==1.5.0
-tensorflow-serving-api==1.4.0


### PR DESCRIPTION
fixes #591 

The `requirements.txt` is added long time ago, seems No longer needed. Should remove this then.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/593)
<!-- Reviewable:end -->
