### PR TITLE
Fix mnist readme service name and deployments name typo

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -703,12 +703,12 @@ kustomize build . |kubectl apply -f -
 
 You can check the deployment by running
 ```
-kubectl describe deployments mnist-deploy-local
+kubectl describe deployments mnist-service-local
 ```
 
-The service should make the `mnist-deploy-local` deployment accessible over port 9000.
+The service should make the `mnist-service-local` deployment accessible over port 9000.
 ```
-kubectl describe service mnist-service
+kubectl describe service mnist-service-local
 ```
 
 ## Web Front End


### PR DESCRIPTION
Fix example/mnist/readme typo of service name and deployment name

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/611)
<!-- Reviewable:end -->
