### PR TITLE
Add tensorboard support for local mninst example

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -16,13 +16,14 @@
       - [Using S3](#using-s3)
   - [Monitoring](#monitoring)
     - [Tensorboard](#tensorboard)
+      - [Local storage](#local-storage-1)
       - [Using GCS](#using-gcs-1)
       - [Using S3](#using-s3-1)
       - [Deploying TensorBoard](#deploying-tensorboard)
   - [Serving the model](#serving-the-model)
     - [GCS](#gcs)
     - [S3](#s3)
-    - [Local storage](#local-storage-1)
+    - [Local storage](#local-storage-2)
   - [Web Front End](#web-front-end)
     - [Connecting via port forwarding](#connecting-via-port-forwarding)
     - [Using IAP on GCP](#using-iap-on-gcp)
@@ -468,6 +469,21 @@ kubectl logs -f mnist-train-dist-chief-0
 There are various ways to monitor workflow/training job. In addition to using `kubectl` to query for the status of `pods`, some basic dashboards are also available.
 
 ### Tensorboard
+
+#### Local storage
+
+Enter the `monitoring/local` from the `mnist` application directory.
+```
+cd monitoring/local
+```
+
+Configure PVC name, mount point, and set log directory.
+```
+kustomize edit add configmap mnist-map-monitoring --from-literal=pvcName=${PVC_NAME}
+kustomize edit add configmap mnist-map-monitoring --from-literal=pvcMountPath=/mnt
+kustomize edit add configmap mnist-map-monitoring --from-literal=logDir=/mnt
+```
+
 
 #### Using GCS
 

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -469,21 +469,6 @@ There are various ways to monitor workflow/training job. In addition to using `k
 
 ### Tensorboard
 
-#### Local storage
-
-Enter the `monitoring/local` from the `mnist` application directory.
-```
-cd monitoring/local
-```
-
-Configure PVC name, mount point, and set log directory.
-```
-kustomize edit add configmap mnist-map-monitoring --from-literal=pvcName=${PVC_NAME}
-kustomize edit add configmap mnist-map-monitoring --from-literal=pvcMountPath=/mnt
-kustomize edit add configmap mnist-map-monitoring --from-literal=logDir=/mnt
-```
-
-
 #### Using GCS
 
 Enter the `monitoring/GCS` from the `mnist` application directory.

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -469,6 +469,21 @@ There are various ways to monitor workflow/training job. In addition to using `k
 
 ### Tensorboard
 
+#### Local storage
+
+Enter the `monitoring/local` from the `mnist` application directory.
+```
+cd monitoring/local
+```
+
+Configure PVC name, mount point, and set log directory.
+```
+kustomize edit add configmap mnist-map-monitoring --from-literal=pvcName=${PVC_NAME}
+kustomize edit add configmap mnist-map-monitoring --from-literal=pvcMountPath=/mnt
+kustomize edit add configmap mnist-map-monitoring --from-literal=logDir=/mnt
+```
+
+
 #### Using GCS
 
 Enter the `monitoring/GCS` from the `mnist` application directory.

--- a/mnist/monitoring/local/deployment_patch.yaml
+++ b/mnist/monitoring/local/deployment_patch.yaml
@@ -1,0 +1,12 @@
+- op: add
+  path: /spec/template/spec/containers/0/volumeMounts
+  value:
+    - mountPath: $(pvcMountPath)
+      name: local-storage
+
+- op: add
+  path: /spec/template/spec/volumes
+  value:
+    - name: local-storage
+      persistentVolumeClaim:
+        claimName: $(pvcName)

--- a/mnist/monitoring/local/kustomization.yaml
+++ b/mnist/monitoring/local/kustomization.yaml
@@ -28,9 +28,3 @@ patchesJson6902:
     kind: Deployment
     name: tensorboard-tb
     version: v1beta1
-configMapGenerator:
-- literals:
-  - logDir=/mnt
-  - pvcMountPath=/mnt
-  - pvcName=pvcname4
-  name: mnist-map-monitoring

--- a/mnist/monitoring/local/kustomization.yaml
+++ b/mnist/monitoring/local/kustomization.yaml
@@ -1,0 +1,36 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+- ../base
+configurations:
+- params.yaml
+
+vars:
+- fieldref:
+    fieldPath: data.pvcName
+  name: pvcName
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mnist-map-monitoring
+- fieldref:
+    fieldPath: data.pvcMountPath
+  name: pvcMountPath
+  objref:
+    apiVersion: v1
+    kind: ConfigMap
+    name: mnist-map-monitoring
+ 
+patchesJson6902:
+- path: deployment_patch.yaml
+  target:
+    group: apps
+    kind: Deployment
+    name: tensorboard-tb
+    version: v1beta1
+configMapGenerator:
+- literals:
+  - logDir=/mnt
+  - pvcMountPath=/mnt
+  - pvcName=pvcname4
+  name: mnist-map-monitoring

--- a/mnist/monitoring/local/params.yaml
+++ b/mnist/monitoring/local/params.yaml
@@ -1,0 +1,5 @@
+varReference:
+- path: spec/template/spec/volumes/persistentVolumeClaim/claimName
+  kind: Deployment
+- path: spec/template/spec/containers/volumeMounts/mountPath
+  kind: Deployment


### PR DESCRIPTION
This PR updates the mninst example to add support for local storage.
An example of usage could be:
- train your model and store the checkpoints and logs in a local storage
- deploy a tensorboard that fetches logs from the previous local storage

Local in this pull request means that the model is trained and saved on a custom PVC. Thus the results and logs of training should be accessible from Tensorboard by mounting this PVC, following  GCS and S3 examples.

Files changed:
- mnist/README.md: New instructions on how to use the logs found in the local storage for monitoring, following the same scheme as the "Training your model" step.
- mnist/monitoring/local/deployment_patch.yaml: Mount the local-storage PVC created in the training step to be accessible by Tensorboard.
- mnist/monitoring/local/kustomization.yaml: Define pvc name and mount path to be accessible in tensorboard
- mnist/monitoring/local/params.yaml: Define claimName and mountPath.
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/616)
<!-- Reviewable:end -->
