### PR TITLE
object_detection: fix typo error in tf-serving.libsonnet

### DIFF
--- a/object_detection/ks-app/vendor/kubeflow/tf-serving/tf-serving.libsonnet
+++ b/object_detection/ks-app/vendor/kubeflow/tf-serving/tf-serving.libsonnet
@@ -119,8 +119,10 @@
       name: $.params.name,
       image: $.params.modelServerImage,
       imagePullPolicy: "IfNotPresent",
-      args: [
+      command: [
         "/usr/bin/tensorflow_model_server",
+      ],
+      args: [
         "--port=9000",
         "--model_name=" + $.params.modelName,
         "--model_base_path=" + $.params.modelPath,


### PR DESCRIPTION
modified tf-serving.libsonnet in object_detection example to fix the error of
"FileSystemStoragePathSource encountered a file-system access error:
Could not find base path /models/model for servable model"

Change-Id: I946a0a7fbb6c80992d66fe003ca90b1c21c67cfc
Signed-off-by: Henry Wang <henry.wang@arm.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/618)
<!-- Reviewable:end -->
