### PR TITLE
MNIST: allow extra arguments in model.py

### DIFF
--- a/mnist/model.py
+++ b/mnist/model.py
@@ -62,7 +62,7 @@ def parse_arguments():
                       default=0.01,
                       help='Learning rate for training.')
 
-  args = parser.parse_args()
+  args = parser.parse_known_args()[0]
   return args
 
 


### PR DESCRIPTION
issue: https://github.com/kubeflow/website/issues/1012

Users are [instructed here](https://github.com/kubeflow/website/issues/1012) to copy/paste this code into a Notebook. It turns out, notebooks pass an extra "-f" argument, which would [cause the argument parser to crash](https://github.com/kubeflow/website/issues/1012). This change allows the parser to ignore extra arguments, so the script can be used in other contexts 

parse_known_args is [explained here](https://docs.python.org/2/library/argparse.html#partial-parsing). It is meant for just this use case

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/625)
<!-- Reviewable:end -->
