### PR TITLE
update kubeflow-fairing commit sha to use job in clusterBuild

### DIFF
--- a/xgboost_synthetic/build-train-deploy.ipynb
+++ b/xgboost_synthetic/build-train-deploy.ipynb
@@ -76,7 +76,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip3 install git+git://github.com/kubeflow/fairing.git@840c272c11452696e4be8e2e5d8f547949da4dc7"
+    "!pip3 install git+git://github.com/kubeflow/fairing.git@b3db9a548b51eea93250c662defe6470283943b3"
    ]
   },
   {


### PR DESCRIPTION
As @jlewi required that cluster builder should use a job not a pod in https://github.com/kubeflow/fairing/issues/349, now this has been implemented by @nrchakradhar in the PR https://github.com/kubeflow/fairing/pull/379. 

The PR is going to update kubeflow-fairing to use new commit-sha to use a job instead of pod for `ClusterBuilder` in the example. And  the job will not be deleted after its done unless user set the `cleaup=True` for `ClusterBuilder` (Implemented in the https://github.com/kubeflow/fairing/pull/379).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/643)
<!-- Reviewable:end -->
