### PR TITLE
Fixes Bugs for the mnist example

### DIFF
--- a/mnist/serving/base/service.yaml
+++ b/mnist/serving/base/service.yaml
@@ -36,4 +36,4 @@ spec:
     targetPort: 8500
   selector:
     app: mnist
-  type: ClusterIP
+  type: LoadBalancer

--- a/mnist/serving/base/service.yaml
+++ b/mnist/serving/base/service.yaml
@@ -36,4 +36,4 @@ spec:
     targetPort: 8500
   selector:
     app: mnist
-  type: LoadBalancer
+  type: ClusterIP

--- a/mnist/web-ui/Dockerfile
+++ b/mnist/web-ui/Dockerfile
@@ -28,7 +28,7 @@ RUN pip --no-cache-dir install \
         h5py \
         ipykernel \
         numpy \
-        tensorflow \
+        tensorflow==1.14.0 \
         tensorflow-serving-api \
         flask \
         && \

--- a/pipelines/mnist-pipelines/deploy-service/Dockerfile
+++ b/pipelines/mnist-pipelines/deploy-service/Dockerfile
@@ -23,11 +23,11 @@ RUN apt-get update -q && apt-get upgrade -y && \
       lsb-release \
       unzip \
       wget && \
-    wget -O /opt/ks_0.12.0_linux_amd64.tar.gz \
-      https://github.com/ksonnet/ksonnet/releases/download/v0.12.0/ks_0.12.0_linux_amd64.tar.gz && \
-    tar -C /opt -xzf /opt/ks_0.12.0_linux_amd64.tar.gz && \
-    cp /opt/ks_0.12.0_linux_amd64/ks /bin/. && \
-    rm -f /opt/ks_0.12.0_linux_amd64.tar.gz && \
+    wget -O /opt/ks_0.13.0_linux_amd64.tar.gz \
+      https://github.com/ksonnet/ksonnet/releases/download/v0.13.0/ks_0.13.0_linux_amd64.tar.gz && \
+    tar -C /opt -xzf /opt/ks_0.13.0_linux_amd64.tar.gz && \
+    cp /opt/ks_0.13.0_linux_amd64/ks /bin/. && \
+    rm -f /opt/ks_0.13.0_linux_amd64.tar.gz && \
     wget -O /bin/kubectl \
       https://storage.googleapis.com/kubernetes-release/release/v1.11.2/bin/linux/amd64/kubectl && \
     chmod u+x /bin/kubectl && \

--- a/pipelines/mnist-pipelines/mnist_pipeline.py
+++ b/pipelines/mnist-pipelines/mnist_pipeline.py
@@ -73,7 +73,7 @@ def mnist_pipeline(model_export_dir='gs://your-bucket/export',
 
   webui_args = [
           '--image', 'gcr.io/kubeflow-examples/mnist/web-ui:'
-                     'latest',
+                     'v20190304-v0.2-176-g15d997b',
           '--name', 'web-ui',
           '--container-port', '5000',
           '--service-port', '80',
@@ -86,7 +86,8 @@ def mnist_pipeline(model_export_dir='gs://your-bucket/export',
 
   web_ui = dsl.ContainerOp(
       name='web-ui',
-      image='gcr.io/kubeflow-examples/mnist/deploy-service:latest',
+      image='gcr.io/kubeflow-examples/mnist/deploy-service:'
+            'v20190304-v0.2-176-g15d997b',
       arguments=webui_args
   )
   web_ui.after(serve)

--- a/pipelines/mnist-pipelines/mnist_pipeline.py
+++ b/pipelines/mnist-pipelines/mnist_pipeline.py
@@ -65,7 +65,7 @@ def mnist_pipeline(model_export_dir='gs://your-bucket/export',
   serve = dsl.ContainerOp(
       name='serve',
       image='gcr.io/ml-pipeline/ml-pipeline-kubeflow-deployer:'
-            '7775692adf28d6f79098e76e839986c9ee55dd61',
+            '8dfa2d9f832e5291649e3bc9d58468da7c6ed92a',
       arguments=serve_args
   )
   serve.after(train)
@@ -73,7 +73,7 @@ def mnist_pipeline(model_export_dir='gs://your-bucket/export',
 
   webui_args = [
           '--image', 'gcr.io/kubeflow-examples/mnist/web-ui:'
-                     'v20190304-v0.2-176-g15d997b-pipelines',
+                     'latest',
           '--name', 'web-ui',
           '--container-port', '5000',
           '--service-port', '80',


### PR DESCRIPTION
This PR has the bug fix for the mnist example for both the end to end flow and the ML pipeline flow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/664)
<!-- Reviewable:end -->

@jlewi 
i) It specifies the TF version to 1.14.0 or 1.15.0 which is the latest stable version that supports TF serving instead of just specifying tensorflow.
ii) In the deploy service Dockerfile it changes the ksonnet version to 0.13.0 because in ksonnet version 0.12.0 there has been a bug reported i.e. Panic Error.
iii) Changes the docker image tag for serving which gives the Panic error while deploying.