### PR TITLE
WIP: Resolve two problems in ci/cd testing.

### DIFF
--- a/test/workflows/components/mnist.jsonnet
+++ b/test/workflows/components/mnist.jsonnet
@@ -15,7 +15,7 @@ local defaultParams = {
   dataVolume: "kubeflow-test-volume",
 
   // Default step image:
-  stepImage: "gcr.io/kubeflow-ci/test-worker/test-worker:v20190116-b7abb8d-e3b0c4",
+  stepImage: "gcr.io/kubeflow-ci/test-worker/test-worker:v20191029-fd24db8-e3b0c4",
 
   // Which Kubeflow cluster to use for running TFJobs on.
   kfProject: "kubeflow-ci-deployment",


### PR DESCRIPTION
The PR is going to fix two issue below:

1.  In the PR #658 and #665 , there is a problem below
```
error: SchemaError(io.k8s.api.certificates.v1beta1.CertificateSigningRequestList): invalid object doesn't have additional properties
```
The root cause is the kubectl version is v1.10.0 in the `test-worker` image, the kubectl has been upgraded in the PR https://github.com/kubeflow/testing/pull/500, but the `test-worker` image is not refreshed. Once `test-worker` refreshed, we can remove the code change for upgrade kubectl in the PR.

2.  For the cluster `kf-vmaster-n00`, there is a problem https://github.com/kubeflow/testing/issues/499,  @jlewi is going to investigate, but we can change to another cluster to work around this now, to avoid blocking other PR merging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/668)
<!-- Reviewable:end -->
