### PR TITLE
Wrong variable used in the client run example - Cookbook kfp_remote_deploy-IAP

### DIFF
--- a/cookbook/pipelines/notebooks/kfp_remote_deploy-IAP.ipynb
+++ b/cookbook/pipelines/notebooks/kfp_remote_deploy-IAP.ipynb
@@ -271,14 +271,14 @@
    "outputs": [],
    "source": [
     "pipeline_name = '[Sample] Basic - Parallel execution'\n",
-    "pipeline_id = get_pipeline_id(name, client)\n",
+    "pipeline_id = get_pipeline_id(pipeline_name, client)\n",
     "if pipeline_id:\n",
     "  print(\"using pipeline ID: %s\" pipeline_id)\n",
     "  res = client.run_pipeline(exp.id, 'parallelexec' + str(ts),\n",
     "                            # params={...},\n",
     "                            pipeline_id=pipeline_id)\n",
     "  else:\n",
-    "    print(\"Could not find Pipeline ID from name %s\" % name)"
+    "    print(\"Could not find Pipeline ID from name %s\" % pipeline_name)"
    ]
   },
   {


### PR DESCRIPTION
In the example where a pipeline is run based upon its id the wrong variable seem to be used. The search is not done using the "pipeline_name" instead of the "name" variable is used.  I believe this is a typo and the goal is to use the "pipeline_name" variable.

In order to fix this i updated to use "pipeline_name". If I am misunderstanding I suggest removing the variable "pipeline_name" since it is not used and creates confusion. 

BTW create example! 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/689)
<!-- Reviewable:end -->
