### PR TITLE
xgboost pin metadata==0.2.0

### DIFF
--- a/xgboost_synthetic/requirements.txt
+++ b/xgboost_synthetic/requirements.txt
@@ -2,7 +2,7 @@ fire
 gitpython
 google-cloud-storage
 joblib
-kubeflow-metadata
+kubeflow-metadata==0.2.0
 numpy
 pandas
 retrying


### PR DESCRIPTION
With new metadata 0.3.0 released, we need to pin the metadata version to 0.2.0 to make current notebook work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/717)
<!-- Reviewable:end -->
