### PR TITLE
mnist example namespace fix

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -229,20 +229,32 @@ kustomize edit add configmap mnist-map-training --from-literal=modelDir=gs://${B
 kustomize edit add configmap mnist-map-training --from-literal=exportDir=gs://${BUCKET}/${MODEL_PATH}/export
 ```
 
-
-You can now submit the job
+Build a yaml file for the `TFJob` specification based on your kustomize config:
 
 ```
-kustomize build . |kubectl apply -f -
+kustomize build . > mnist-training.yaml
 ```
 
-And you can check the job status
+Then, in `mnist-training.yaml`, search for this line: `namespace: kubeflow`.
+Edit it to **replace `kubeflow` with the name of your user profile namespace**,
+which will probably have the form `kubeflow-<username>`.  (If you're not sure what this
+namespace is called, you can find it in the top menubar of the Kubeflow Central
+Dashboard.)
+
+After you've updated the namespace, apply the `TFJob` specification to the
+Kubeflow cluster:
+
+```
+kubectl apply -f mnist-training.yaml
+```
+
+You can then check the job status:
 
 ```
 kubectl get tfjobs -o yaml mnist-train-dist
 ```
 
-And to check the logs 
+And to check the logs:
 
 ```
 kubectl logs -f mnist-train-dist-chief-0

--- a/mnist/README.md
+++ b/mnist/README.md
@@ -251,13 +251,13 @@ kubectl apply -f mnist-training.yaml
 You can then check the job status:
 
 ```
-kubectl get tfjobs -o yaml mnist-train-dist
+kubectl get tfjobs -n <your-user-namespace> -o yaml mnist-train-dist
 ```
 
 And to check the logs:
 
 ```
-kubectl logs -f mnist-train-dist-chief-0
+kubectl logs -n <your-user-namespace> -f mnist-train-dist-chief-0
 ```
 
 #### Using S3


### PR DESCRIPTION
This is necessary b/c the kubeflow namespace, by default, doesn't have sufficient permissions.
Addresses https://github.com/kubeflow/examples/issues/713.

This is a quick fix, just so it continues to work. When there's time, we can figure out how to address it via kustomize config instead. 

cc @DanSanche  -- LMK you'd rather approach this differently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/720)
<!-- Reviewable:end -->
