### PR TITLE
Update mnist_gcp.ipynb - increase training step value

### DIFF
--- a/mnist/mnist_gcp.ipynb
+++ b/mnist/mnist_gcp.ipynb
@@ -341,7 +341,7 @@
     "num_workers = 2\n",
     "model_dir = f\"gs://{bucket}/mnist\"\n",
     "export_path = f\"gs://{bucket}/mnist/export\" \n",
-    "train_steps = 200\n",
+    "train_steps = 2000\n",
     "batch_size = 100\n",
     "learning_rate = .01\n",
     "image = cluster_builder.image_tag\n",


### PR DESCRIPTION
Increasing the train_steps value allows training progress info to show up in the logs.  (Apparently 200 steps was too small for that).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/747)
<!-- Reviewable:end -->
