### PR TITLE
Bump notebook image version for  xgboost-test

### DIFF
--- a/xgboost_synthetic/testing/conftest.py
+++ b/xgboost_synthetic/testing/conftest.py
@@ -11,7 +11,7 @@ def pytest_addoption(parser):
     default="kubeflow-kf-ci-v1-user")
   parser.addoption(
     "--image", help="Notebook image to use", type=str,
-    default="gcr.io/kubeflow-images-public/tensorflow-1.14.0-notebook-gpu"
+    default="gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu"
     ":v0.7.0")
   parser.addoption(
     "--repos", help="The repos to checkout; leave blank to use defaults",

--- a/xgboost_synthetic/testing/conftest.py
+++ b/xgboost_synthetic/testing/conftest.py
@@ -12,7 +12,7 @@ def pytest_addoption(parser):
   parser.addoption(
     "--image", help="Notebook image to use", type=str,
     default="gcr.io/kubeflow-images-public/tensorflow-2.1.0-notebook-gpu"
-    ":v0.7.0")
+    ":1.0.0")
   parser.addoption(
     "--repos", help="The repos to checkout; leave blank to use defaults",
     type=str, default="")

--- a/xgboost_synthetic/testing/xgboost_test.py
+++ b/xgboost_synthetic/testing/xgboost_test.py
@@ -11,12 +11,6 @@ from kubernetes import client as k8s_client
 from kubeflow.testing import argo_build_util
 from kubeflow.testing import util
 
-# TODO(jlewi): This test is currently failing because various things
-# need to be updated to work with 0.7.0. Until that's fixed we mark it
-# as expected to fail on presubmits. We only mark it as expected to fail
-# on presubmits because if expected failures don't show up in test grid
-# and we want signal in postsubmits and periodics
-@pytest.mark.xfail(os.getenv("JOB_TYPE") == "presubmit", reason="Flaky")
 def test_xgboost_synthetic(record_xml_attribute, name, namespace, # pylint: disable=too-many-branches,too-many-statements
                            repos, image, notebook_artifacts_dir):
   '''Generate Job and summit.'''


### PR DESCRIPTION
Notebook image tensorflow1.14 is no longer available in KF v1.0; and ML-metadata needs tf version > 1.14

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/examples/760)
<!-- Reviewable:end -->
