### PR TITLE
Add link to the 'Deploying Kubeflow on GCP' doc

### DIFF
--- a/mnist/mnist_gcp.ipynb
+++ b/mnist/mnist_gcp.ipynb
@@ -14,7 +14,7 @@
     "  \n",
     "## Requirements\n",
     "\n",
-    "  * You must be running Kubeflow 1.0 on Kubernetes Engine (GKE) with Cloud Identity-Aware Proxy (Cloud IAP).\n",
+    "  * You must be running Kubeflow 1.0 on Kubernetes Engine (GKE) with Cloud Identity-Aware Proxy (Cloud IAP). See the guide to [deploying Kubeflow on GCP](https://www.kubeflow.org/docs/gke/deploy/).\n",
     "  * Run this notebook within your Kubeflow cluster. See the guide to [setting up your Kubeflow notebooks](https://www.kubeflow.org/docs/notebooks/setup/).\n",
     " "
    ]


### PR DESCRIPTION
This is important as this is an E2E tutorial. Moreover, the catch that GCP Free Tier and the 12-month trial period with $300 credit does not offer enough resources to run default GCP installation of Kubeflow is mentioned in those docs.  Fixes #778.