### PR TITLE
Remove multiple import statements in Mnist example

### DIFF
--- a/mnist/mnist_gcp.ipynb
+++ b/mnist/mnist_gcp.ipynb
@@ -144,7 +144,6 @@
     }
    ],
    "source": [
-    "from kubernetes import client as k8s_client\n",
     "from kubernetes.client import rest as k8s_rest\n",
     "from kubeflow import fairing   \n",
     "from kubeflow.fairing import utils as fairing_utils\n",

--- a/mnist/mnist_gcp.ipynb
+++ b/mnist/mnist_gcp.ipynb
@@ -112,6 +112,7 @@
     "reload(kubeflow)\n",
     "from kubernetes import client as k8s_client\n",
     "from kubernetes import config as k8s_config\n",
+    "from kubernetes.client import rest as k8s_rest\n",
     "from kubeflow.tfjob.api import tf_job_client as tf_job_client_module\n",
     "from IPython.core.display import display, HTML\n",
     "import yaml"
@@ -144,7 +145,6 @@
     }
    ],
    "source": [
-    "from kubernetes.client import rest as k8s_rest\n",
     "from kubeflow import fairing   \n",
     "from kubeflow.fairing import utils as fairing_utils\n",
     "from kubeflow.fairing.builders import append\n",


### PR DESCRIPTION
In Kubeflow examples notebook, I found multiple import statements in kubeflow Mnist GCP deployment