### PR TITLE
update commit version of requirements.txt

### DIFF
--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,4 +1,4 @@
 # Refer to latest commit in github.com/kubeflow/fairing
-git+git://github.com/kubeflow/fairing.git@7e4c23c47a6b0544a722d04e1f9910c2f283a4f6
+git+git://github.com/kubeflow/fairing.git@8b08bf7d2703c97901efe8a80717eeccb1133194
 retrying==1.3.3
 google-api-core[grpc]>=1.15.0


### PR DESCRIPTION
When I ran mnist_gcp.ipynb according to the current kubeflow tutorial, the following events occurred.

<img width="841" alt="スクリーンショット 2020-04-30 17 12 16" src="https://user-images.githubusercontent.com/32013786/80689298-1534c300-8b08-11ea-88d8-57a113800c52.png">

requirements.txtのコミットバージョンが古いことが原因と考えられるため、
プルリクエストを送らせていただきます。

We will send you a pull request because we think it is due to an outdated commit version of requirements.txt.
