### PR TITLE
Update fairing in mnist to 1.0.1

### DIFF
--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,4 +1,4 @@
 # Refer to latest commit in github.com/kubeflow/fairing
-git+git://github.com/kubeflow/fairing.git@6717b3d3806c8093adf1186bc819ad887238f287
+git+git://github.com/kubeflow/fairing.git@v1.0.1
 retrying==1.3.3
 google-api-core[grpc]>=1.15.0


### PR DESCRIPTION
This is a fix for kubeflow/kfserving#806. The existing version of
fairing isn't compatible with the 0.3 version of the KFServing SDK.