### PR TITLE
Removed form action attribute

### DIFF
--- a/mnist/web-ui/templates/index.html
+++ b/mnist/web-ui/templates/index.html
@@ -40,7 +40,7 @@ limitations under the License.
                <div class="mdl-card mdl-cell mdl-cell--12-col">
                   <div class="mdl-card__supporting-text">
                      <h4>MNIST Model Server</h4>
-                     <form action="/">
+                     <form>
                         <div class="mdl-textfield mdl-js-textfield mdl-textfield--floating-label" style="width:250px">
                            <input class="mdl-textfield__input" type="text" id="server-name" name="name" value="{{ args.name }}">
                            <label class="mdl-textfield__label" for="sample1">Model Name</label>


### PR DESCRIPTION
While accessing mnist ui from GCP hosted end point, takes to root url, as action attribute performs submit on /

Mnist ui url:
https:/${KUBEFlOW_ENDPOINT}/mnist/${NAMESPACE}/ui/   

Have removed action attribute, page will do submit on self.

Ref :
https://stackoverflow.com/questions/13520127/submit-html-form-on-self-page