### PR TITLE
pin version of h5py to 2.10.0 for Azure Pipeline Example

### DIFF
--- a/pipelines/azurepipeline/code/deploy/environment.yml
+++ b/pipelines/azurepipeline/code/deploy/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - tensorflow==2.0.0-alpha0
   - Pillow
   - requests
+  - h5py==2.10.0

--- a/pipelines/azurepipeline/code/training/requirements.txt
+++ b/pipelines/azurepipeline/code/training/requirements.txt
@@ -1,2 +1,3 @@
 Pillow
 pathlib2
+h5py==2.10.0


### PR DESCRIPTION
pin version of h5py to 2.10.0 since tensorflow 2.0.0 did not pin the version and h5py 3.0.0 broke the model loading code

#### Exception
'str' object has no attribute 'decode' for https://github.com/kubeflow/examples/blob/master/pipelines/azurepipeline/code/deploy/score.py#L21

https://github.com/tensorflow/tensorflow/issues/44467
