### PR TITLE
[MNIST] Update fairing to 1.0.2 to resolve import bug

### DIFF
--- a/mnist/requirements.txt
+++ b/mnist/requirements.txt
@@ -1,4 +1,3 @@
-# Refer to latest commit in github.com/kubeflow/fairing
-git+git://github.com/kubeflow/fairing.git@v1.0.1
+kubeflow-fairing==1.0.2
 retrying==1.3.3
 google-api-core[grpc]>=1.15.0


### PR DESCRIPTION
resolves #828 

The current fairing library in the MNIST example has the `ImportError: You need to install 'msrestazure' to use this feature` error. Updating fairing to 1.0.2 using PyPI can solve this issue.