### PR TITLE
Remove jlewi@ from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,5 +1,2 @@
-# TODO(jlewi): We should probably have OWNERs files in subdirectories that
-# list approvers for individual components (e.g. Seldon folks for Seldon component)
 approvers:
   - jinchihe
-  - jlewi


### PR DESCRIPTION
* jlewi@ is no longer actively involved in maintaining the examples.

cc @kubeflow/project-steering-group it looks like we are missing sufficient OWNERs for the examples repo.