### PR TITLE
Change the version of h5py to avoid crash

### DIFF
--- a/pipelines/azurepipeline/code/deploy/environment.yml
+++ b/pipelines/azurepipeline/code/deploy/environment.yml
@@ -17,3 +17,4 @@ dependencies:
   - tensorflow==2.0.0-alpha0
   - Pillow
   - requests
+  - h5py==2.10.0

--- a/pipelines/azurepipeline/code/training/requirements.txt
+++ b/pipelines/azurepipeline/code/training/requirements.txt
@@ -1,2 +1,3 @@
 Pillow
 pathlib2
+h5py==2.10.0


### PR DESCRIPTION
The h5py package version is supposed to be 2.10.0 to make sure there is no crash in deployment.