### PR TITLE
Update link to Kubeflow on AWS

### DIFF
--- a/mnist/README.md
+++ b/mnist/README.md
@@ -41,7 +41,7 @@ Follow these instructions to run the MNIST tutorial on GCP
 
 Follow these instructions to run the MNIST tutorial on AWS
 
-1. Follow the [AWS instructions](https://www.kubeflow.org/docs/aws/deploy/install-kubeflow/) to deploy Kubeflow on AWS
+1. Follow the [AWS instructions](https://www.kubeflow.org/docs/distributions/aws/) to deploy Kubeflow on AWS
 
 1. Launch a Jupyter notebook
 


### PR DESCRIPTION
## Existing link not found
https://www.kubeflow.org/docs/distributions/aws/deploy/install-kubeflow/ is not found
![Screenshot from 2022-05-18 14-33-17](https://user-images.githubusercontent.com/3925641/169159504-18766e47-f737-400b-bc8e-40e35d2babb3.png)

## Update it to be a valid page
For Kubeflow on AWS, current version of documentation only having this page https://www.kubeflow.org/docs/distributions/aws/ , so I put it here in this PR.
![Screenshot from 2022-05-18 14-35-40](https://user-images.githubusercontent.com/3925641/169159797-c3cad767-3086-46af-8a83-f8f441ba962d.png)

