### PR TITLE
Bound example dependencies to avoid future warnings and issues

### DIFF
--- a/digit-recognition-kaggle-competition/digit-recognizer-kale.ipynb
+++ b/digit-recognition-kaggle-competition/digit-recognizer-kale.ipynb
@@ -861,7 +861,7 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
+   "docker_image": "",
    "experiment": {
     "id": "new",
     "name": "digit-recognizer-kale"

--- a/digit-recognition-kaggle-competition/digit-recognizer-kfp.ipynb
+++ b/digit-recognition-kaggle-competition/digit-recognizer-kfp.ipynb
@@ -660,7 +660,7 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
+   "docker_image": "",
    "experiment": {
     "id": "6f6c9b81-54e3-414b-974a-6fe8b445a59e",
     "name": "digit_recognize_lightweight"

--- a/digit-recognition-kaggle-competition/requirements.txt
+++ b/digit-recognition-kaggle-competition/requirements.txt
@@ -1,4 +1,4 @@
-pandas
-seaborn
+pandas==1.1.5
+seaborn==0.9.0
 tensorflow==2.3.0
-wget
+wget==3.2

--- a/house-prices-kaggle-competition/house-prices-kale.ipynb
+++ b/house-prices-kaggle-competition/house-prices-kale.ipynb
@@ -1144,7 +1144,7 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
+   "docker_image": "",
    "experiment": {
     "id": "new",
     "name": "house-prices"

--- a/house-prices-kaggle-competition/house-prices-kfp.ipynb
+++ b/house-prices-kaggle-competition/house-prices-kfp.ipynb
@@ -748,7 +748,7 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
+   "docker_image": "",
    "experiment": {
     "id": "",
     "name": ""

--- a/house-prices-kaggle-competition/requirements.txt
+++ b/house-prices-kaggle-competition/requirements.txt
@@ -1,7 +1,7 @@
-numpy
-pandas
-matplotlib
-sklearn
-seaborn
-category_encoders
-xgboost
+numpy==1.18.5
+pandas==1.1.5
+matplotlib==3.3.4
+scikit-learn==0.23.2
+seaborn==0.9.0
+category_encoders==2.5.0
+xgboost==1.5.1

--- a/natural-language-processing-with-disaster-tweets-kaggle-competition/natural-language-processing-with-disaster-tweets-kale.ipynb
+++ b/natural-language-processing-with-disaster-tweets-kaggle-competition/natural-language-processing-with-disaster-tweets-kale.ipynb
@@ -182,33 +182,37 @@
     }
    ],
    "source": [
-    "import pandas as pd\n",
-    "import matplotlib.pyplot as plt\n",
-    "import seaborn as sns\n",
-    "import numpy as np\n",
+    "import re\n",
     "import nltk\n",
-    "nltk.download('stopwords')\n",
-    "nltk.download('punkt')\n",
+    "import gensim\n",
+    "import string\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "import seaborn as sns\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "from nltk.tokenize import word_tokenize\n",
+    "\n",
     "from nltk.corpus import stopwords\n",
     "from nltk.util import ngrams\n",
+    "from sklearn.model_selection import train_test_split\n",
     "from sklearn.feature_extraction.text import CountVectorizer\n",
     "from collections import defaultdict\n",
     "from collections import  Counter\n",
-    "plt.style.use('ggplot')\n",
-    "stop=set(stopwords.words('english'))\n",
-    "import re\n",
-    "from nltk.tokenize import word_tokenize\n",
-    "import gensim\n",
-    "import string\n",
-    "from keras.preprocessing.text import Tokenizer\n",
-    "from keras.preprocessing.sequence import pad_sequences\n",
-    "from tqdm import tqdm\n",
-    "from keras.models import Sequential\n",
-    "from keras.layers import Embedding,LSTM,Dense,SpatialDropout1D\n",
-    "from keras.initializers import Constant\n",
-    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "from tensorflow.keras.preprocessing.text import Tokenizer\n",
+    "from tensorflow.keras.preprocessing.sequence import pad_sequences\n",
+    "from tensorflow.keras.models import Sequential\n",
+    "from tensorflow.keras.layers import Embedding,LSTM,Dense,SpatialDropout1D\n",
+    "from tensorflow.keras.initializers import Constant\n",
     "from tensorflow.keras.optimizers import Adam\n",
-    "\n"
+    "\n",
+    "nltk.download('stopwords')\n",
+    "nltk.download('punkt')\n",
+    "stop=set(stopwords.words('english'))\n",
+    "plt.style.use('ggplot')"
    ]
   },
   {
@@ -1491,13 +1495,7 @@
     "model.add(embedding)\n",
     "model.add(SpatialDropout1D(0.2))\n",
     "model.add(LSTM(64, dropout=0.2, recurrent_dropout=0.2))\n",
-    "model.add(Dense(1, activation='sigmoid'))\n",
-    "\n",
-    "\n",
-    "optimzer=Adam(learning_rate=1e-5)\n",
-    "\n",
-    "model.compile(loss='binary_crossentropy',optimizer=optimzer,metrics=['accuracy'])\n",
-    "\n"
+    "model.add(Dense(1, activation='sigmoid'))"
    ]
   },
   {
@@ -1621,6 +1619,7 @@
     }
    ],
    "source": [
+    "model.compile(loss='binary_crossentropy', optimizer=Adam(learning_rate=1e-5), metrics=['accuracy'])\n",
     "history=model.fit(X_train,y_train,batch_size=4,epochs=5,validation_data=(X_test,y_test),verbose=2)"
    ]
   },

--- a/natural-language-processing-with-disaster-tweets-kaggle-competition/natural-language-processing-with-disaster-tweets-kale.ipynb
+++ b/natural-language-processing-with-disaster-tweets-kaggle-competition/natural-language-processing-with-disaster-tweets-kale.ipynb
@@ -1765,7 +1765,7 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
+   "docker_image": "",
    "experiment": {
     "id": "new",
     "name": "trial-with-kale"

--- a/natural-language-processing-with-disaster-tweets-kaggle-competition/natural-language-processing-with-disaster-tweets-kfp.ipynb
+++ b/natural-language-processing-with-disaster-tweets-kaggle-competition/natural-language-processing-with-disaster-tweets-kfp.ipynb
@@ -557,7 +557,7 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
+   "docker_image": "",
    "experiment": {
     "id": "",
     "name": ""

--- a/natural-language-processing-with-disaster-tweets-kaggle-competition/requirements.txt
+++ b/natural-language-processing-with-disaster-tweets-kaggle-competition/requirements.txt
@@ -1,10 +1,7 @@
-seaborn
-nltk
-sklearn
-collection
-gensim
-keras
-tensorflow
-pyspellchecker
-wget
-zipfile36
+matplotlib==3.3.4
+seaborn==0.9.0
+nltk==3.6.7
+scikit-learn==0.23.2
+gensim==4.2.0
+tensorflow==2.3.0
+wget==3.2


### PR DESCRIPTION
This PR introduces the following changes:

For the "natural language processing with disaster tweets" example:
- Bound the version of the dependencies.
- Change any 'import keras.*' import statement to 'import tensorflow.keras.*' as the example does not require the standalone Keras library.

For the "house prices kaggle competition" example:
- Bounds the version of the dependencies.

For the "digit recognition kaggle competition" example:
- Bounds the version of the dependencies.

Signed-off-by: Dimitris Poulopoulos <dimpo@arrikto.com>
