### PR TITLE
Update links to use kubeflow/examples as base for JPX tutorial

### DIFF
--- a/jpx-tokyo-stock-exchange-kaggle-competition/README.md
+++ b/jpx-tokyo-stock-exchange-kaggle-competition/README.md
@@ -1,6 +1,6 @@
 # Objective
 
-In this example we are going to convert this generic [notebook](https://github.com/josepholaide/examples/blob/master/jpx-tokyo-stock-exchange-kaggle-competition/jpx-tokyo-stock-exchange-prediction-orig.ipynb) based on the [Kaggle JPX Tokyo Stock Exchange Prediction](https://www.kaggle.com/competitions/jpx-tokyo-stock-exchange-prediction) competition into a Kubeflow pipeline.
+In this example we are going to convert this generic [notebook](./jpx-tokyo-stock-exchange-prediction-orig.ipynb) based on the [Kaggle JPX Tokyo Stock Exchange Prediction](https://www.kaggle.com/competitions/jpx-tokyo-stock-exchange-prediction) competition into a Kubeflow pipeline.
 
 The objective of this task is to correctly model real future returns of around 2,000 stocks. The stocks are ranked from highest 
 to lowest expected returns and they are evaluated on the difference in returns between the top and bottom 200 stocks.


### PR DESCRIPTION
Ensure all links are relative for the JPX tutorial. Relevant PR https://github.com/kubeflow/examples/pull/1003

cc @jimmyguerrero @josepholaide 