### PR TITLE
Update the examples with correct image paths and packages

### DIFF
--- a/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kale.ipynb
+++ b/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kale.ipynb
@@ -966,7 +966,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "2efb8e27-3b2e-439b-a53c-b1f9d7b94cfc",
     "name": "g-research-crypto-forecasting"

--- a/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kale.ipynb
+++ b/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kale.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# 🪙 G-Research Crypto Kale Pipeline\n",
-    "![](./images/vector-blockchain-poster.jpg?raw=true)\n",
+    "![](./images/vector-blockchain-poster.jpg)\n",
     "\n",
     "---\n"
    ]

--- a/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kfp.ipynb
+++ b/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kfp.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# 🪙 G-Research Crypto Kubeflow Pipeline\n",
-    "![](./images/vector-blockchain-poster.jpg?raw=true)\n",
+    "![](./images/vector-blockchain-poster.jpg)\n",
     "\n",
     "---\n"
    ]

--- a/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kfp.ipynb
+++ b/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-kfp.ipynb
@@ -740,7 +740,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "2efb8e27-3b2e-439b-a53c-b1f9d7b94cfc",
     "name": "g-research-crypto-forecasting"

--- a/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-orig.ipynb
+++ b/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-orig.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# 🪙 G-Research Crypto Original Notebook\n",
-    "![](./images/vector-blockchain-poster.jpg?raw=true)\n",
+    "![](./images/vector-blockchain-poster.jpg)\n",
     "\n",
     "---\n"
    ]

--- a/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-orig.ipynb
+++ b/G-research-crypto-forecasting-kaggle-competition/g-research-crypto-forecast-orig.ipynb
@@ -955,7 +955,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "2efb8e27-3b2e-439b-a53c-b1f9d7b94cfc",
     "name": "g-research-crypto-forecasting"

--- a/G-research-crypto-forecasting-kaggle-competition/requirements.txt
+++ b/G-research-crypto-forecasting-kaggle-competition/requirements.txt
@@ -2,4 +2,5 @@ kaggle
 pandas
 tqdm
 lightgbm
-talib-binary
+ta-lib-binary
+numpy==1.20.0

--- a/american-express-default-kaggle-competition/american-express-default-prediction-kale.ipynb
+++ b/american-express-default-kaggle-competition/american-express-default-prediction-kale.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# 🪙 American Express - Default Prediction Competition Kale Pipeline\n",
-    "![](./images/background.jpg?raw=true)\n",
+    "![](./images/background.jpg)\n",
     "\n",
     "---\n",
     "\n",

--- a/american-express-default-kaggle-competition/american-express-default-prediction-kale.ipynb
+++ b/american-express-default-kaggle-competition/american-express-default-prediction-kale.ipynb
@@ -713,7 +713,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "american-express-defaul-prediction"

--- a/american-express-default-kaggle-competition/american-express-default-prediction-kfp.ipynb
+++ b/american-express-default-kaggle-competition/american-express-default-prediction-kfp.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# 🪙 American Express - Default Prediction Competition Vanilla KFP Pipeline\n",
-    "![](./images/background.jpg?raw=true)\n",
+    "![](./images/background.jpg)\n",
     "\n",
     "---\n",
     "\n",

--- a/american-express-default-kaggle-competition/american-express-default-prediction-kfp.ipynb
+++ b/american-express-default-kaggle-competition/american-express-default-prediction-kfp.ipynb
@@ -709,7 +709,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "2efb8e27-3b2e-439b-a53c-b1f9d7b94cfc",
     "name": "g-research-crypto-forecasting"

--- a/american-express-default-kaggle-competition/american-express-default-prediction-orig.ipynb
+++ b/american-express-default-kaggle-competition/american-express-default-prediction-orig.ipynb
@@ -814,7 +814,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "2efb8e27-3b2e-439b-a53c-b1f9d7b94cfc",
     "name": "g-research-crypto-forecasting"

--- a/american-express-default-kaggle-competition/american-express-default-prediction-orig.ipynb
+++ b/american-express-default-kaggle-competition/american-express-default-prediction-orig.ipynb
@@ -7,7 +7,7 @@
    },
    "source": [
     "# 🪙 American Express - Default Prediction Competition Original Notebook\n",
-    "![](./images/background.jpg?raw=true)\n",
+    "![](./images/background.jpg)\n",
     "\n",
     "---\n",
     "\n",

--- a/digit-recognition-kaggle-competition/digit-recognizer-kale.ipynb
+++ b/digit-recognition-kaggle-competition/digit-recognizer-kale.ipynb
@@ -861,7 +861,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "",
    "experiment": {
     "id": "new",
     "name": "digit-recognizer-kale"

--- a/digit-recognition-kaggle-competition/digit-recognizer-kfp.ipynb
+++ b/digit-recognition-kaggle-competition/digit-recognizer-kfp.ipynb
@@ -660,7 +660,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "",
    "experiment": {
     "id": "6f6c9b81-54e3-414b-974a-6fe8b445a59e",
     "name": "digit_recognize_lightweight"

--- a/digit-recognition-kaggle-competition/digit-recognizer-orig.ipynb
+++ b/digit-recognition-kaggle-competition/digit-recognizer-orig.ipynb
@@ -1179,7 +1179,6 @@
     },
     "kubeflow_notebook": {
       "autosnapshot": true,
-      "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
       "experiment": {
         "id": "new",
         "name": "digit-recognizer-kale"

--- a/digit-recognition-kaggle-competition/digit_recognizer_orig.ipynb
+++ b/digit-recognition-kaggle-competition/digit_recognizer_orig.ipynb
@@ -1179,7 +1179,6 @@
     },
     "kubeflow_notebook": {
       "autosnapshot": true,
-      "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
       "experiment": {
         "id": "new",
         "name": "digit-recognizer-kale"

--- a/facial-keypoints-detection-kaggle-competition/facial-keypoints-detection-kale.ipynb
+++ b/facial-keypoints-detection-kaggle-competition/facial-keypoints-detection-kale.ipynb
@@ -436,7 +436,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": false,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "c2268016-e4ff-4bea-8fc3-9b7ee1e56a25",
     "name": "Kale-pipelines"

--- a/facial-keypoints-detection-kaggle-competition/facial-keypoints-detection-kfp.ipynb
+++ b/facial-keypoints-detection-kaggle-competition/facial-keypoints-detection-kfp.ipynb
@@ -69,7 +69,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "",
     "name": ""

--- a/facial-keypoints-detection-kaggle-competition/facial-keypoints-detection-orig.ipynb
+++ b/facial-keypoints-detection-kaggle-competition/facial-keypoints-detection-orig.ipynb
@@ -537,7 +537,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": false,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "c2268016-e4ff-4bea-8fc3-9b7ee1e56a25",
     "name": "Kale-pipelines"

--- a/h-and-m-fash-rec-kaggle-competition/h&m-fash-rec-kale.ipynb
+++ b/h-and-m-fash-rec-kaggle-competition/h&m-fash-rec-kale.ipynb
@@ -617,7 +617,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "hm-fash-recomm"

--- a/h-and-m-fash-rec-kaggle-competition/h&m-fash-rec-kfp.ipynb
+++ b/h-and-m-fash-rec-kaggle-competition/h&m-fash-rec-kfp.ipynb
@@ -556,7 +556,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "",
     "name": ""

--- a/h-and-m-fash-rec-kaggle-competition/h&m-fash-rec-orig.ipynb
+++ b/h-and-m-fash-rec-kaggle-competition/h&m-fash-rec-orig.ipynb
@@ -381,7 +381,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "",
     "name": ""

--- a/jpx-tokyo-stock-exchange-kaggle-competition/jpx-tokyo-stock-exchange-prediction-kale.ipynb
+++ b/jpx-tokyo-stock-exchange-kaggle-competition/jpx-tokyo-stock-exchange-prediction-kale.ipynb
@@ -2198,7 +2198,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "jpx-tokyo-stock-exchange"

--- a/jpx-tokyo-stock-exchange-kaggle-competition/jpx-tokyo-stock-exchange-prediction-kfp.ipynb
+++ b/jpx-tokyo-stock-exchange-kaggle-competition/jpx-tokyo-stock-exchange-prediction-kfp.ipynb
@@ -625,7 +625,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "jpx-tokyo-stock-exchange"

--- a/jpx-tokyo-stock-exchange-kaggle-competition/jpx-tokyo-stock-exchange-prediction-orig.ipynb
+++ b/jpx-tokyo-stock-exchange-kaggle-competition/jpx-tokyo-stock-exchange-prediction-orig.ipynb
@@ -2085,7 +2085,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "jpx-tokyo-stock-exchange"

--- a/store-sales-forecasting-kaggle-competition/store-sales-kale.ipynb
+++ b/store-sales-forecasting-kaggle-competition/store-sales-kale.ipynb
@@ -450,7 +450,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "store-sales-forecast"

--- a/store-sales-forecasting-kaggle-competition/store-sales-kfp.ipynb
+++ b/store-sales-forecasting-kaggle-competition/store-sales-kfp.ipynb
@@ -577,7 +577,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "8b9ab23a-f26c-475d-baa7-1b4e6e26c816",
     "name": "store-sales-forecast"

--- a/store-sales-forecasting-kaggle-competition/store-sales-orig.ipynb
+++ b/store-sales-forecasting-kaggle-competition/store-sales-orig.ipynb
@@ -2201,7 +2201,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "",
     "name": ""

--- a/telco-customer-churn-kaggle-competition/telco-customer-churn-kale.ipynb
+++ b/telco-customer-churn-kaggle-competition/telco-customer-churn-kale.ipynb
@@ -1729,7 +1729,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "telco"

--- a/telco-customer-churn-kaggle-competition/telco-customer-churn-kfp.ipynb
+++ b/telco-customer-churn-kaggle-competition/telco-customer-churn-kfp.ipynb
@@ -969,7 +969,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "new",
     "name": "telco"

--- a/telco-customer-churn-kaggle-competition/telco-customer-churn-orig.ipynb
+++ b/telco-customer-churn-kaggle-competition/telco-customer-churn-orig.ipynb
@@ -1647,7 +1647,6 @@
   },
   "kubeflow_notebook": {
    "autosnapshot": true,
-   "docker_image": "gcr.io/arrikto/jupyter-kale-py36@sha256:dd3f92ca66b46d247e4b9b6a9d84ffbb368646263c2e3909473c3b851f3fe198",
    "experiment": {
     "id": "",
     "name": ""


### PR DESCRIPTION
Some of the examples had issues with
1. The images would not get rendered correctly, due to jupyter not parsing query params correctly
2. The Kale image was explicitly set in the notebook metadata
3. Some packages needed some updates

cc @akgraner @jimmyguerrero