### PR TITLE
fix broken link to subdirectory

### DIFF
--- a/demos/README.md
+++ b/demos/README.md
@@ -12,6 +12,6 @@ that's suitable for presentation to public audiences.
 * [Simple pipeline](simple_pipeline/): highlights the use of pipelines and
   hyperparameter tuning on a GKE cluster with node autoprovisioning.
 
-* [Recurring Run](recurring_run/): A  simple demo that illustrates how to use
+* [Recurring Run](recurring/): A  simple demo that illustrates how to use
   the Kubeflow Pipelines SDK to provision [recurring
   runs](https://www.kubeflow.org/docs/components/pipelines/concepts/run/).


### PR DESCRIPTION
while reading about demo I noticed one of the MD links to the subdirectory was broken; this fixes it :) 