### PR TITLE
Update kserve sdk example to version 0.15.0

### DIFF
--- a/kserve/sdk/first_isvc_kserve.ipynb
+++ b/kserve/sdk/first_isvc_kserve.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install kserve==0.7.0"
+    "!pip install kserve==0.15.0"
    ]
   },
   {
@@ -40,7 +40,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "a38cbeda-eb60-4469-b861-559950886453",
    "metadata": {},
    "outputs": [],
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "6a621ac9-1847-4249-b12a-76cf23620534",
    "metadata": {},
    "outputs": [],
@@ -94,7 +94,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "9a7f9b69-a305-482b-a9e1-0b706ba11341",
    "metadata": {},
    "outputs": [],
@@ -104,13 +104,13 @@
     "api_version = constants.KSERVE_GROUP + '/' + kserve_version\n",
     "\n",
     "isvc = V1beta1InferenceService(api_version=api_version,\n",
-    "                               kind=constants.KSERVE_KIND,\n",
+    "                               kind=constants.KSERVE_KIND_INFERENCESERVICE,\n",
     "                               metadata=client.V1ObjectMeta(\n",
     "                                   name=name, namespace=namespace, annotations={'sidecar.istio.io/inject':'false'}),\n",
     "                               spec=V1beta1InferenceServiceSpec(\n",
     "                               predictor=V1beta1PredictorSpec(\n",
     "                               sklearn=(V1beta1SKLearnSpec(\n",
-    "                                   storage_uri=\"gs://kfserving-samples/models/sklearn/iris\"))))\n",
+    "                                   storage_uri=\"gs://kfserving-examples/models/sklearn/1.0/model\"))))\n",
     ")"
    ]
   },
@@ -189,7 +189,7 @@
     "  ]\n",
     "}\n",
     "\n",
-    "response = requests.post(isvc_url, json=inference_input)\n",
+    "response = requests.post(f\"{isvc_url}/v1/models/{name}:predict\", json=inference_input)\n",
     "print(response.text)"
    ]
   },
@@ -221,7 +221,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl create -f https://raw.githubusercontent.com/kserve/kserve/release-0.7/docs/samples/v1beta1/sklearn/v1/perf.yaml -n kubeflow-user-example-com"
+    "creation_output=!kubectl create -f https://raw.githubusercontent.com/kserve/kserve/release-0.15/docs/samples/v1beta1/sklearn/v1/perf.yaml -n {namespace}\n",
+    "creation_output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a17377b8-30b8-43c2-a39c-da6aded3ff40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "job_name = creation_output[0].split(\"/\")[-1].split(\" \")[0]\n",
+    "job_name"
    ]
   },
   {
@@ -239,7 +251,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl get pods --namespace=kubeflow-user-example-com | grep load"
+    "get_pod_output=!kubectl get pods -n {namespace} | grep {job_name}\n",
+    "get_pod_output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2d6318ef-0360-4eae-8775-f1a1ac6e5fac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pod_name=get_pod_output[0].split(\" \")[0]\n",
+    "pod_name"
    ]
   },
   {
@@ -257,7 +281,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl logs <job-name> -n kubeflow-user-example-com"
+    "!kubectl logs {pod_name} -n {namespace}"
    ]
   },
   {
@@ -302,7 +326,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -316,7 +340,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.11.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changes:
- Pip command to install version `0.15.0`.
-  Modify kind to point to the new name
- New model URI as the old one is not available anymore.
- Add the prediction route.
- Automatically extract job name instead of requesting the user to change it.

